### PR TITLE
Rv/background track

### DIFF
--- a/api-v1/get/inbound-number.mdx
+++ b/api-v1/get/inbound-number.mdx
@@ -43,10 +43,16 @@ description: "Retrieve settings for your inbound phone number."
   The webhook URL, if any, where transcripts are sent after each call to the number completes.
 </ResponseField>
 
-<ResponseField name="voice_" type="integer">
-  The `voice` your agent is using - will be a `reduce_latency` voice. 
+<ResponseField name="voice" type="integer">
+  The `voice` your agent is currently using.
   
   For more information, see [List Voices](/api-v1/get/voices).
+</ResponseField>
+
+<ResponseField name="background_track" type="string">
+  The background track your agent is using.
+
+  Will be `null` by default, until an option such as `office`, cafe`, `restaurant`, or `none` is applied.
 </ResponseField>
 
 <ResponseField name="pathway_id" type="string">

--- a/api-v1/get/inbound-number.mdx
+++ b/api-v1/get/inbound-number.mdx
@@ -52,7 +52,7 @@ description: "Retrieve settings for your inbound phone number."
 <ResponseField name="background_track" type="string">
   The background track your agent is using.
 
-  Will be `null` by default, until an option such as `office`, cafe`, `restaurant`, or `none` is applied.
+  Will be `null` by default, until an option such as `office`, `cafe`, `restaurant`, or `none` is applied.
 </ResponseField>
 
 <ResponseField name="pathway_id" type="string">

--- a/api-v1/post/calls.mdx
+++ b/api-v1/post/calls.mdx
@@ -133,6 +133,19 @@ description: "Send an AI phone call with a custom objective and actions."
   </Accordion>
 </ParamField>
 
+<ParamField body="background_track" type="string" default={null}>
+  Select an audio track that you'd like to play in the background during the call. The audio will play continuously when the agent isn't speaking, and is incorporated into it's speech as well.
+
+  Use this to provide a more natural, seamless, engaging experience for the conversation. We've found this creates a significantly smoother call experience by minimizing the stark differences between total silence and the agent's speech.
+
+  Options:
+  - `null` - Default, will play audible but quiet phone static.
+  - `office` - Office-style soundscape. Includes faint typing, chatter, clicks, and other office sounds.
+  - `cafe` - Cafe-like soundscape. Includes faint talking, clinking, and other cafe sounds.
+  - `restaurant` - Similar to `cafe`, but more subtle.
+  - `none` - Minimizes background noise
+</ParamField>
+
 <ParamField body="first_sentence" type="string">
   Makes your agent say a specific phrase or sentence for it's first response.
 </ParamField>

--- a/api-v1/post/inbound-number-update.mdx
+++ b/api-v1/post/inbound-number-update.mdx
@@ -68,6 +68,19 @@ description: "Update your inbound agent's settings, prompt and other details."
   Set your agent's voice - all available voices can be found with the [List Voices](/api-v1/get/voices) endpoint.
 </ParamField>
 
+<ParamField body="background_track" type="string" default={null}>
+  Select an audio track that you'd like to play in the background during the call. The audio will play continuously when the agent isn't speaking, and is incorporated into it's speech as well.
+
+  Use this to provide a more natural, seamless, engaging experience for the conversation. We've found this creates a significantly smoother call experience by minimizing the stark differences between total silence and the agent's speech.
+
+  Options:
+  - `null` - Default, will play audible but quiet phone static.
+  - `office` - Office-style soundscape. Includes faint typing, chatter, clicks, and other office sounds.
+  - `cafe` - Cafe-like soundscape. Includes faint talking, clinking, and other cafe sounds.
+  - `restaurant` - Similar to `cafe`, but more subtle.
+  - `none` - Minimizes background noise
+</ParamField>
+
 <ParamField body="first_sentence" type="string">
   Makes your agent say a specific phrase or sentence for it's first response.
 </ParamField>


### PR DESCRIPTION
- adds `background_track` parameter
- Default: `null`, options: office, cafe, restaurant, none (as of now)