### PR TITLE
Checking if whitespace was breaking prod playground

### DIFF
--- a/api-v1/get/calls-id.mdx
+++ b/api-v1/get/calls-id.mdx
@@ -1,4 +1,4 @@
---- 
+---
 title: "Call Details"
 api: "GET https://api.bland.ai/v1/calls/{call_id}" 
 description: "Retrieve detailed information, metadata and transcripts for a call."

--- a/api-v1/get/event-stream.mdx
+++ b/api-v1/get/event-stream.mdx
@@ -1,4 +1,4 @@
---- 
+---
 title: "Event Stream"
 api: "GET https://api.bland.ai/v1/event_stream/{call_id}" 
 description: "Retrieve stream of events that occured during the call."


### PR DESCRIPTION
calls-id and event stream pages have broken playgrounds (only in prod, not dev mintlify env), check if it is from this extra whitespace in the header.