### PR TITLE
jwt auth audience clarification

### DIFF
--- a/enterprise-features/jwt-authentication.mdx
+++ b/enterprise-features/jwt-authentication.mdx
@@ -58,8 +58,12 @@ Every JWT Bland issues contains these claims and headers:
 
 **Audience (aud)**:
 
-- Leave blank: Auto-populates with request URL
+- Leave blank: Auto-populates with request's base URL in the form of protocol://host
 - Custom value: Use for service mesh routing (e.g., `svc:webhook-processor`)
+- Examples (when auto populated):
+  - `https://webhooks.yourdomain.com?queryparam=value` => `https://webhooks.yourdomain.com`
+  - `https://api.yourdomain.com/v1/endpoint` => `https://api.yourdomain.com`
+- Use the "Include Protocol" option to control whether the `https://` prefix is included in the `aud` claim.
 
 **Token Expiration**: Seconds until token expires (300-3600)
 


### PR DESCRIPTION
- clarify how `aud` claims are populated