### PR TITLE
fix: docs-for-agents link → /llms.txt across 282 pages

### DIFF
--- a/api-v1/delete/agent-testing-scenarios-id.mdx
+++ b/api-v1/delete/agent-testing-scenarios-id.mdx
@@ -32,4 +32,4 @@ description: "Delete a test scenario and all related data."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/alarms-id.mdx
+++ b/api-v1/delete/alarms-id.mdx
@@ -36,4 +36,4 @@ Returns a `204 No Content` response on success.
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/blocked-numbers-id.mdx
+++ b/api-v1/delete/blocked-numbers-id.mdx
@@ -47,4 +47,4 @@ description: "Permanently delete a block rule."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/guard-rails-id.mdx
+++ b/api-v1/delete/guard-rails-id.mdx
@@ -40,4 +40,4 @@ Returns a `204 No Content` response on success.
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/knowledge-id.mdx
+++ b/api-v1/delete/knowledge-id.mdx
@@ -78,4 +78,4 @@ curl -X DELETE https://api.bland.ai/v1/knowledge/kb_01H8X9QK5R2N7P3M6Z8W4Y1V5T \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/org_leave_self_memberships_id.mdx
+++ b/api-v1/delete/org_leave_self_memberships_id.mdx
@@ -37,4 +37,4 @@ description: "Remove the authenticated user from an organization."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/orgs.mdx
+++ b/api-v1/delete/orgs.mdx
@@ -43,4 +43,4 @@ description: "Delete an organization."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/pathway_folder.mdx
+++ b/api-v1/delete/pathway_folder.mdx
@@ -25,4 +25,4 @@ description: "Deletes a specific folder for the authenticated user. The folder m
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/pathway_version.mdx
+++ b/api-v1/delete/pathway_version.mdx
@@ -40,4 +40,4 @@ description: "Marks a specific version of a pathway as archived, effectively del
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/personas-id.mdx
+++ b/api-v1/delete/personas-id.mdx
@@ -93,4 +93,4 @@ description: "Delete a persona."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/sip-port-cancel.mdx
+++ b/api-v1/delete/sip-port-cancel.mdx
@@ -42,4 +42,4 @@ curl -X DELETE https://api.bland.ai/v1/sip/port/port_xyz789 \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/sms-conversations-message.mdx
+++ b/api-v1/delete/sms-conversations-message.mdx
@@ -58,4 +58,4 @@ description: "Delete SMS conversations by their IDs."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/sms-conversations.mdx
+++ b/api-v1/delete/sms-conversations.mdx
@@ -47,4 +47,4 @@ description: "Delete a specific conversation and all of its associated messages.
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/tools-tool-id.mdx
+++ b/api-v1/delete/tools-tool-id.mdx
@@ -33,4 +33,4 @@ description: "Delete your Custom Tool."
     
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/vectors-id.mdx
+++ b/api-v1/delete/vectors-id.mdx
@@ -25,4 +25,4 @@ description: "Remove a knowledge base from your account."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/voices-id.mdx
+++ b/api-v1/delete/voices-id.mdx
@@ -32,4 +32,4 @@ description: "Delete an existing cloned voice."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/delete/widget-custom-components-id.mdx
+++ b/api-v1/delete/widget-custom-components-id.mdx
@@ -29,4 +29,4 @@ description: "Deletes a specific custom component by ID."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/active.mdx
+++ b/api-v1/get/active.mdx
@@ -100,4 +100,4 @@ description: "Retrieve all currently active calls for your organization. Active 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/agent-testing-analytics-enhanced.mdx
+++ b/api-v1/get/agent-testing-analytics-enhanced.mdx
@@ -238,4 +238,4 @@ description: "Get enhanced testing analytics including node failure heatmap, wea
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/agent-testing-analytics.mdx
+++ b/api-v1/get/agent-testing-analytics.mdx
@@ -88,4 +88,4 @@ description: "Get basic testing analytics for a pathway over a time window."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/agent-testing-batches-id.mdx
+++ b/api-v1/get/agent-testing-batches-id.mdx
@@ -137,4 +137,4 @@ description: "Retrieve a test batch and all its runs."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/agent-testing-runs-id.mdx
+++ b/api-v1/get/agent-testing-runs-id.mdx
@@ -203,4 +203,4 @@ description: "Retrieve detailed results for a specific test run including chat h
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/agent-testing-runs.mdx
+++ b/api-v1/get/agent-testing-runs.mdx
@@ -121,4 +121,4 @@ description: "List test runs with optional filtering and pagination."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/agent-testing-scenarios-id.mdx
+++ b/api-v1/get/agent-testing-scenarios-id.mdx
@@ -175,4 +175,4 @@ description: "Retrieve a specific test scenario with its assertions."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/agent-testing-scenarios.mdx
+++ b/api-v1/get/agent-testing-scenarios.mdx
@@ -173,4 +173,4 @@ description: "List all test scenarios for your organization."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/agent-testing-simulation-sets-id.mdx
+++ b/api-v1/get/agent-testing-simulation-sets-id.mdx
@@ -173,4 +173,4 @@ description: "Retrieve a simulation set with its statistics including pass rates
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/agent-testing-templates.mdx
+++ b/api-v1/get/agent-testing-templates.mdx
@@ -92,4 +92,4 @@ description: "List out-of-box test scenario templates. Templates are automatical
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/agent-testing-tornado-active.mdx
+++ b/api-v1/get/agent-testing-tornado-active.mdx
@@ -83,4 +83,4 @@ Returns `404 Not Found` if no active tornado session exists for the specified pa
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/agent-testing-tornado-status.mdx
+++ b/api-v1/get/agent-testing-tornado-status.mdx
@@ -182,4 +182,4 @@ description: "Get detailed progress for a tornado session including iteration da
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/agents.mdx
+++ b/api-v1/get/agents.mdx
@@ -57,4 +57,4 @@ description: "Retrieves each web agent you've created, along with their settings
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/alarms-history.mdx
+++ b/api-v1/get/alarms-history.mdx
@@ -87,4 +87,4 @@ description: "Get recent alarm events across all alarms in your organization."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/alarms-id.mdx
+++ b/api-v1/get/alarms-id.mdx
@@ -86,4 +86,4 @@ description: "Get a single alarm configuration by ID."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/alarms.mdx
+++ b/api-v1/get/alarms.mdx
@@ -92,4 +92,4 @@ description: "List alarm configurations for your organization."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/all_pathway.mdx
+++ b/api-v1/get/all_pathway.mdx
@@ -274,4 +274,4 @@ description: "Returns a set of information about all the conversational pathways
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/audit-logs.mdx
+++ b/api-v1/get/audit-logs.mdx
@@ -171,4 +171,4 @@ New event types are added over time. Filter by prefix (e.g. `auth.*`, `pathway.*
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/blocked-numbers-id.mdx
+++ b/api-v1/get/blocked-numbers-id.mdx
@@ -82,4 +82,4 @@ description: "Retrieve the details of a specific block rule."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/blocked-numbers.mdx
+++ b/api-v1/get/blocked-numbers.mdx
@@ -76,4 +76,4 @@ description: "Retrieve block rules associated with your inbound numbers."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/calls-corrected-transcript.mdx
+++ b/api-v1/get/calls-corrected-transcript.mdx
@@ -383,4 +383,4 @@ This will contain an array of objects. Each object will be constructed as the fo
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/calls-id-recording.mdx
+++ b/api-v1/get/calls-id-recording.mdx
@@ -51,4 +51,4 @@ description: "Retrieve an audio stream for a call recording."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/calls-id.mdx
+++ b/api-v1/get/calls-id.mdx
@@ -389,4 +389,4 @@ description: "Retrieve detailed information, metadata and transcripts for a call
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/calls.mdx
+++ b/api-v1/get/calls.mdx
@@ -175,4 +175,4 @@ description: "Returns a set of metadata for each call dispatched by your account
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/citation-schemas-id.mdx
+++ b/api-v1/get/citation-schemas-id.mdx
@@ -122,4 +122,4 @@ description: "Retrieve a specific citation schema by ID."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/citation-schemas-list.mdx
+++ b/api-v1/get/citation-schemas-list.mdx
@@ -64,4 +64,4 @@ description: "Retrieve all citation schemas for your organization."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/contacts-find.mdx
+++ b/api-v1/get/contacts-find.mdx
@@ -168,4 +168,4 @@ Returns the contact with related data, or `null` if not found.
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/contacts-id.mdx
+++ b/api-v1/get/contacts-id.mdx
@@ -151,4 +151,4 @@ description: "Retrieve a contact by its unique ID, including all identifiers, co
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/contacts.mdx
+++ b/api-v1/get/contacts.mdx
@@ -143,4 +143,4 @@ description: "List all contacts for your organization. Each contact includes ide
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/custom-dialing-pool.mdx
+++ b/api-v1/get/custom-dialing-pool.mdx
@@ -163,4 +163,4 @@ print(response.json())
 </ResponseExample> 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/custom-dialing-pools.mdx
+++ b/api-v1/get/custom-dialing-pools.mdx
@@ -144,4 +144,4 @@ print(response.json())
 </ResponseExample> 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/event-stream.mdx
+++ b/api-v1/get/event-stream.mdx
@@ -39,4 +39,4 @@ When the event occurred.
 </ResponseField>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/folder_pathways.mdx
+++ b/api-v1/get/folder_pathways.mdx
@@ -45,4 +45,4 @@ description: "Retrieves all pathways within a specific folder for the authentica
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/guard-rails-id.mdx
+++ b/api-v1/get/guard-rails-id.mdx
@@ -108,4 +108,4 @@ description: "Retrieve a specific guard rail by ID."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/guard-rails.mdx
+++ b/api-v1/get/guard-rails.mdx
@@ -126,4 +126,4 @@ description: "Retrieve a list of all guard rails in your organization."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/inbound-number.mdx
+++ b/api-v1/get/inbound-number.mdx
@@ -97,4 +97,4 @@ description: "Retrieve settings for your inbound phone number."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/inbound.mdx
+++ b/api-v1/get/inbound.mdx
@@ -73,4 +73,4 @@ description: "Retrieves a list of all inbound phone numbers configured for your 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/knowledge-id.mdx
+++ b/api-v1/get/knowledge-id.mdx
@@ -131,4 +131,4 @@ curl -X GET https://api.bland.ai/v1/knowledge/kb_01H8X9QK5R2N7P3M6Z8W4Y1V5T \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/knowledge.mdx
+++ b/api-v1/get/knowledge.mdx
@@ -152,4 +152,4 @@ curl -X GET "https://api.bland.ai/v1/knowledge?page=2&limit=10" \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/me.mdx
+++ b/api-v1/get/me.mdx
@@ -48,4 +48,4 @@ The total number of calls you've made.
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/memory-changes.mdx
+++ b/api-v1/get/memory-changes.mdx
@@ -100,4 +100,4 @@ description: "Retrieve what memory was captured or updated during a specific cal
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/memory-contact-id-messages.mdx
+++ b/api-v1/get/memory-contact-id-messages.mdx
@@ -80,4 +80,4 @@ description: "Retrieve the recent message history for a contact memory. Returns 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/memory-contact-id.mdx
+++ b/api-v1/get/memory-contact-id.mdx
@@ -139,4 +139,4 @@ description: "Retrieve a contact's full memory record by ID, including their con
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/memory-context.mdx
+++ b/api-v1/get/memory-context.mdx
@@ -161,4 +161,4 @@ description: "Retrieve the full memory context for a contact scoped to a persona
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/memory-memory-id.mdx
+++ b/api-v1/get/memory-memory-id.mdx
@@ -112,4 +112,4 @@ description: "Retrieve detailed information about a specific memory store and it
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/memory.mdx
+++ b/api-v1/get/memory.mdx
@@ -74,4 +74,4 @@ description: "Retrieve all memory stores associated with your account."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/node_test_run.mdx
+++ b/api-v1/get/node_test_run.mdx
@@ -197,4 +197,4 @@ description: "Retrieve a node test run."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/org_billing_information.mdx
+++ b/api-v1/get/org_billing_information.mdx
@@ -53,4 +53,4 @@ description: "Retrieve the current billing details for an organization."
 </ResponseExample> 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/org_billing_refill_information.mdx
+++ b/api-v1/get/org_billing_refill_information.mdx
@@ -37,4 +37,4 @@ description: "Retrieve the recharge amount for an organization's billing."
 </ResponseExample> 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/org_current_version.mdx
+++ b/api-v1/get/org_current_version.mdx
@@ -49,4 +49,4 @@ description: "Retrieve the current version of a specified service for an organiz
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/org_list_self_memberships.mdx
+++ b/api-v1/get/org_list_self_memberships.mdx
@@ -81,4 +81,4 @@ description: "Retrieve a list of organizations the authenticated user is a membe
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/org_list_versions.mdx
+++ b/api-v1/get/org_list_versions.mdx
@@ -108,4 +108,4 @@ description: "Retrieve a list of available versions for a specified service with
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/org_members.mdx
+++ b/api-v1/get/org_members.mdx
@@ -105,4 +105,4 @@ description: "Retrieve the list of members in an organization."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/orgs.mdx
+++ b/api-v1/get/orgs.mdx
@@ -115,4 +115,4 @@ description: "Retrieve details of an organization."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/pathway-chat.mdx
+++ b/api-v1/get/pathway-chat.mdx
@@ -44,4 +44,4 @@ The chat ID created from the /pathway/chat/create endpoint.
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/pathway-generate-status-job-id.mdx
+++ b/api-v1/get/pathway-generate-status-job-id.mdx
@@ -90,4 +90,4 @@ description: "Poll pathway generation status and retrieve the generated pathway 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/pathway-session.mdx
+++ b/api-v1/get/pathway-session.mdx
@@ -69,4 +69,4 @@ description: "Creates a new pathway session token for the authenticated user. Th
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/pathway.mdx
+++ b/api-v1/get/pathway.mdx
@@ -280,4 +280,4 @@ description: "Returns a set of information about the conversational pathway in y
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/pathway_folders.mdx
+++ b/api-v1/get/pathway_folders.mdx
@@ -49,4 +49,4 @@ description: "Retrieves all folders for the authenticated user, including folder
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/pathway_version.mdx
+++ b/api-v1/get/pathway_version.mdx
@@ -96,4 +96,4 @@ description: "Retrieves a specific version of a pathway, including its name, nod
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/pathway_versions.mdx
+++ b/api-v1/get/pathway_versions.mdx
@@ -60,4 +60,4 @@ description: "Retrieves all versions of a specific pathway, including version nu
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/personas-id-versions-version-id.mdx
+++ b/api-v1/get/personas-id-versions-version-id.mdx
@@ -120,4 +120,4 @@ description: "Retrieve a specific persona version."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/personas-id-versions.mdx
+++ b/api-v1/get/personas-id-versions.mdx
@@ -119,4 +119,4 @@ description: "Retrieve all versions of a specific persona."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/personas-id.mdx
+++ b/api-v1/get/personas-id.mdx
@@ -210,4 +210,4 @@ description: "Retrieve a specific persona."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/personas.mdx
+++ b/api-v1/get/personas.mdx
@@ -282,4 +282,4 @@ description: "Retrieve a list of all personas in your organization."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/postcall-webhooks-get.mdx
+++ b/api-v1/get/postcall-webhooks-get.mdx
@@ -80,4 +80,4 @@ Retrieve the post call webhook data for a specific call using its call ID. This 
 </ResponseField>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/prompts-id.mdx
+++ b/api-v1/get/prompts-id.mdx
@@ -58,4 +58,4 @@ description: "Retrieves data for a specific prompt_id."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/prompts.mdx
+++ b/api-v1/get/prompts.mdx
@@ -37,4 +37,4 @@ description: "Retrieves all your saved prompts."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/sip-calls.mdx
+++ b/api-v1/get/sip-calls.mdx
@@ -71,4 +71,4 @@ curl -X GET 'https://api.bland.ai/v1/sip/calls?phone_number=%2B14150000000&limit
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/sip-config.mdx
+++ b/api-v1/get/sip-config.mdx
@@ -71,4 +71,4 @@ curl -X GET 'https://api.bland.ai/v1/sip?phone_number=%2B14150000000' \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/sip-discover-status.mdx
+++ b/api-v1/get/sip-discover-status.mdx
@@ -29,4 +29,4 @@ curl -X GET 'https://api.bland.ai/v1/sip/discover/status?discovery_id=disc_abc12
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/sip-firewall-ips.mdx
+++ b/api-v1/get/sip-firewall-ips.mdx
@@ -51,4 +51,4 @@ curl -X GET https://api.bland.ai/v1/sip/firewall-ips \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/sip-numbers.mdx
+++ b/api-v1/get/sip-numbers.mdx
@@ -51,4 +51,4 @@ curl -X GET https://api.bland.ai/v1/sip/numbers \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/sip-outbound-setup.mdx
+++ b/api-v1/get/sip-outbound-setup.mdx
@@ -54,4 +54,4 @@ curl -X GET https://api.bland.ai/v1/sip/outbound-setup \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/sip-port-check.mdx
+++ b/api-v1/get/sip-port-check.mdx
@@ -57,4 +57,4 @@ curl -X GET 'https://api.bland.ai/v1/sip/port/check?phone_numbers[]=%2B141500000
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/sip-port-requests.mdx
+++ b/api-v1/get/sip-port-requests.mdx
@@ -54,4 +54,4 @@ curl -X GET https://api.bland.ai/v1/sip/port \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/sip-status.mdx
+++ b/api-v1/get/sip-status.mdx
@@ -50,4 +50,4 @@ curl -X GET 'https://api.bland.ai/v1/sip/status?phone_number=%2B14150000000' \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/sip-test-call-status.mdx
+++ b/api-v1/get/sip-test-call-status.mdx
@@ -60,4 +60,4 @@ curl -X GET 'https://api.bland.ai/v1/sip/test-call/status?call_id=tc_abc123' \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/sms-conversations-id.mdx
+++ b/api-v1/get/sms-conversations-id.mdx
@@ -220,4 +220,4 @@ description: "Retrieve a single SMS conversation and its messages by its ID"
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/sms-conversations-webhook.mdx
+++ b/api-v1/get/sms-conversations-webhook.mdx
@@ -92,4 +92,4 @@ description: "Retrieve the webhook delivery log for an SMS conversation, includi
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/sms-conversations.mdx
+++ b/api-v1/get/sms-conversations.mdx
@@ -175,4 +175,4 @@ description: "Retrieve a paginated list of SMS conversations for the authenticat
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/sms-numbers.mdx
+++ b/api-v1/get/sms-numbers.mdx
@@ -133,4 +133,4 @@ description: "Retrieve all phone numbers configured for SMS, along with their co
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/speak-samples-id.mdx
+++ b/api-v1/get/speak-samples-id.mdx
@@ -90,4 +90,4 @@ With `?format=audio`, returns a raw WAV audio binary (same as the original `POST
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/speak-samples.mdx
+++ b/api-v1/get/speak-samples.mdx
@@ -102,4 +102,4 @@ description: "List your stored text-to-speech generations."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/tools-tool-id.mdx
+++ b/api-v1/get/tools-tool-id.mdx
@@ -70,4 +70,4 @@ description: "Retrieve a Custom Tool you've created."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/tools.mdx
+++ b/api-v1/get/tools.mdx
@@ -68,4 +68,4 @@ description: "Retrieve Custom Tools you've created."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/vectors-id.mdx
+++ b/api-v1/get/vectors-id.mdx
@@ -49,4 +49,4 @@ description: "View the details for a specific knowledge base."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/vectors.mdx
+++ b/api-v1/get/vectors.mdx
@@ -57,4 +57,4 @@ description: "List all knowledge bases in your account."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/voices-id.mdx
+++ b/api-v1/get/voices-id.mdx
@@ -66,4 +66,4 @@ description: "Retrieve detailed information about a specific voice."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/voices.mdx
+++ b/api-v1/get/voices.mdx
@@ -106,4 +106,4 @@ description: "Retrieves all available voices for your account."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/widget-custom-components.mdx
+++ b/api-v1/get/widget-custom-components.mdx
@@ -62,4 +62,4 @@ description: "Retrieves a specific custom component by ID."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/widget-id-threads.mdx
+++ b/api-v1/get/widget-id-threads.mdx
@@ -125,4 +125,4 @@ This endpoint does not return 404 if no threads exist; it returns an empty array
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/widget-id.mdx
+++ b/api-v1/get/widget-id.mdx
@@ -65,4 +65,4 @@ description: "Retrieves a specific widget by ID."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/widgets.mdx
+++ b/api-v1/get/widgets.mdx
@@ -61,4 +61,4 @@ description: "Retrieves all widgets associated with your account."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/alarms-id.mdx
+++ b/api-v1/patch/alarms-id.mdx
@@ -117,4 +117,4 @@ description: "Update an alarm configuration."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/citation-schemas.mdx
+++ b/api-v1/patch/citation-schemas.mdx
@@ -186,4 +186,4 @@ description: "Update an existing citation schema's name, description, or schema 
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/contacts-id.mdx
+++ b/api-v1/patch/contacts-id.mdx
@@ -105,4 +105,4 @@ description: "Update an existing contact's information."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/guard-rails-id.mdx
+++ b/api-v1/patch/guard-rails-id.mdx
@@ -152,4 +152,4 @@ All fields are optional. Only include fields you want to update.
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/memory-contact-id-facts.mdx
+++ b/api-v1/patch/memory-contact-id-facts.mdx
@@ -98,4 +98,4 @@ Facts can store any structured information about the contact:
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/memory-contact-id-summary.mdx
+++ b/api-v1/patch/memory-contact-id-summary.mdx
@@ -81,4 +81,4 @@ description: "Overwrite the conversation summary for a contact memory. The summa
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/org_member_permissions.mdx
+++ b/api-v1/patch/org_member_permissions.mdx
@@ -59,4 +59,4 @@ description: "Modify the permissions of an existing member within an organizatio
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/org_members.mdx
+++ b/api-v1/patch/org_members.mdx
@@ -59,4 +59,4 @@ description: "Add or remove members from an organization."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/org_properties.mdx
+++ b/api-v1/patch/org_properties.mdx
@@ -130,4 +130,4 @@ description: "Modify specific properties of an organization."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/org_version.mdx
+++ b/api-v1/patch/org_version.mdx
@@ -49,4 +49,4 @@ description: "Update the current version of a specified service for an organizat
 </ResponseExample> 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/personas-id-inbound-phone-settings.mdx
+++ b/api-v1/patch/personas-id-inbound-phone-settings.mdx
@@ -115,4 +115,4 @@ description: "Update persona-specific settings for a phone number attached to a 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/personas-id.mdx
+++ b/api-v1/patch/personas-id.mdx
@@ -220,4 +220,4 @@ description: "Update an existing persona configuration."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/sip-config.mdx
+++ b/api-v1/patch/sip-config.mdx
@@ -80,4 +80,4 @@ curl -X PATCH https://api.bland.ai/v1/sip/config \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/sms-conversations-id.mdx
+++ b/api-v1/patch/sms-conversations-id.mdx
@@ -82,4 +82,4 @@ description: "Updates properties of an existing SMS conversation."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/vectors-id.mdx
+++ b/api-v1/patch/vectors-id.mdx
@@ -56,4 +56,4 @@ Usage: Pass the `vector_id` into your agent's `tools` to enable the agent to use
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/voices-id.mdx
+++ b/api-v1/patch/voices-id.mdx
@@ -43,4 +43,4 @@ description: "Update the name of an existing cloned voice."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/widget-custom-components-id.mdx
+++ b/api-v1/patch/widget-custom-components-id.mdx
@@ -98,4 +98,4 @@ description: "Retrieves a specific custom component by ID."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/patch/widget-id.mdx
+++ b/api-v1/patch/widget-id.mdx
@@ -97,4 +97,4 @@ description: "Updates an existing widget. All fields in the request body are opt
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/accounts-delete.mdx
+++ b/api-v1/post/accounts-delete.mdx
@@ -41,4 +41,4 @@ description: "Disable an encrypted key for a Twilio account integration. See [Cu
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/accounts.mdx
+++ b/api-v1/post/accounts.mdx
@@ -36,4 +36,4 @@ description: "Integrate your own Twilio account with Bland. See [Custom Twilio I
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/agent-testing-batch-run.mdx
+++ b/api-v1/post/agent-testing-batch-run.mdx
@@ -63,4 +63,4 @@ description: "Execute multiple test scenarios as a batch. Returns immediately wi
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/agent-testing-runs-analyze.mdx
+++ b/api-v1/post/agent-testing-runs-analyze.mdx
@@ -91,4 +91,4 @@ description: "Run AI-powered analysis on a failed test run to get root cause and
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/agent-testing-scenarios-generate.mdx
+++ b/api-v1/post/agent-testing-scenarios-generate.mdx
@@ -85,4 +85,4 @@ The response contains the generated scenario data. This data is **not yet saved*
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/agent-testing-scenarios-run.mdx
+++ b/api-v1/post/agent-testing-scenarios-run.mdx
@@ -57,4 +57,4 @@ description: "Execute a single test scenario. Returns immediately with a run ID 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/agent-testing-scenarios.mdx
+++ b/api-v1/post/agent-testing-scenarios.mdx
@@ -255,4 +255,4 @@ description: "Create a new test scenario with assertions for a pathway or person
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/agent-testing-simulation-sets.mdx
+++ b/api-v1/post/agent-testing-simulation-sets.mdx
@@ -72,4 +72,4 @@ This endpoint is rate limited. All `scenario_ids` must belong to your organizati
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/agent-testing-templates-clone.mdx
+++ b/api-v1/post/agent-testing-templates-clone.mdx
@@ -121,4 +121,4 @@ description: "Clone a template to create a new scenario bound to your pathway or
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/agent-testing-tornado-cancel.mdx
+++ b/api-v1/post/agent-testing-tornado-cancel.mdx
@@ -32,4 +32,4 @@ description: "Cancel a running tornado session."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/agent-testing-tornado-start.mdx
+++ b/api-v1/post/agent-testing-tornado-start.mdx
@@ -81,4 +81,4 @@ Only one tornado session can be active per pathway. Returns `409 Conflict` if a 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/agents-id-authorize.mdx
+++ b/api-v1/post/agents-id-authorize.mdx
@@ -78,4 +78,4 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/agents-id-delete.mdx
+++ b/api-v1/post/agents-id-delete.mdx
@@ -37,4 +37,4 @@ description: "Delete a web agent."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/agents-id.mdx
+++ b/api-v1/post/agents-id.mdx
@@ -203,4 +203,4 @@ description: "Update your web agent's settings, prompt and other details."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/agents.mdx
+++ b/api-v1/post/agents.mdx
@@ -234,4 +234,4 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/alarms-id-notify.mdx
+++ b/api-v1/post/alarms-id-notify.mdx
@@ -92,4 +92,4 @@ description: "Send a test alarm or recovery notification."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/alarms-id-toggle.mdx
+++ b/api-v1/post/alarms-id-toggle.mdx
@@ -109,4 +109,4 @@ description: "Enable or disable an alarm."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/alarms-id-trigger.mdx
+++ b/api-v1/post/alarms-id-trigger.mdx
@@ -76,4 +76,4 @@ description: "Manually trigger alarm evaluation with current data."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/alarms.mdx
+++ b/api-v1/post/alarms.mdx
@@ -125,4 +125,4 @@ description: "Create an alarm configuration for your organization."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/blocked-numbers-id-edit.mdx
+++ b/api-v1/post/blocked-numbers-id-edit.mdx
@@ -96,4 +96,4 @@ description: "Update attributes of an existing block rule."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/blocked-numbers.mdx
+++ b/api-v1/post/blocked-numbers.mdx
@@ -76,4 +76,4 @@ description: "Create one or more block rules to prevent specific phone numbers f
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/calls-active-stop.mdx
+++ b/api-v1/post/calls-active-stop.mdx
@@ -48,4 +48,4 @@ description: "End all active phone calls on your account."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/calls-id-analyze.mdx
+++ b/api-v1/post/calls-id-analyze.mdx
@@ -86,4 +86,4 @@ description: "Analyzes a call of calls based using questions and goals."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/calls-id-listen.mdx
+++ b/api-v1/post/calls-id-listen.mdx
@@ -209,4 +209,4 @@ socket.onclose = () => {
 - The WebSocket URL can be used by multiple connections simultaneously
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/calls-id-stop.mdx
+++ b/api-v1/post/calls-id-stop.mdx
@@ -48,4 +48,4 @@ description: "End an active phone call by call_id."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/calls-simple-pathway.mdx
+++ b/api-v1/post/calls-simple-pathway.mdx
@@ -85,4 +85,4 @@ Links - [Video Tutorial](https://www.loom.com/share/5ce5a84ec97149efad7cf5eff66a
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/calls-simple.mdx
+++ b/api-v1/post/calls-simple.mdx
@@ -52,4 +52,4 @@ description: "Send an AI phone call using a task."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/calls.mdx
+++ b/api-v1/post/calls.mdx
@@ -1901,4 +1901,4 @@ Send an AI phone call with a custom objective and actions. This endpoint can be 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/citation-schemas-backfill.mdx
+++ b/api-v1/post/citation-schemas-backfill.mdx
@@ -484,4 +484,4 @@ Returned when an unexpected error occurs starting the workflow.
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/citation-schemas.mdx
+++ b/api-v1/post/citation-schemas.mdx
@@ -198,4 +198,4 @@ Create a citation schema to define what data should be extracted from call trans
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/clone.mdx
+++ b/api-v1/post/clone.mdx
@@ -421,4 +421,4 @@ result = response.json()
 Once created, your BTTS voice clone can be used from our /speak endpoint, by referencing the returned `voice_id` or `name`.
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/contacts-merge.mdx
+++ b/api-v1/post/contacts-merge.mdx
@@ -123,4 +123,4 @@ When merging contacts:
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/contacts-resolve.mdx
+++ b/api-v1/post/contacts-resolve.mdx
@@ -135,4 +135,4 @@ description: "Find an existing contact or create a new one."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/create_pathway_folder.mdx
+++ b/api-v1/post/create_pathway_folder.mdx
@@ -45,4 +45,4 @@ description: "Creates a new folder for the authenticated user."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/create_pathway_version.mdx
+++ b/api-v1/post/create_pathway_version.mdx
@@ -92,4 +92,4 @@ description: "Creates a new version of a specific pathway, including its name, n
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/custom-dialing-pool-update.mdx
+++ b/api-v1/post/custom-dialing-pool-update.mdx
@@ -211,4 +211,4 @@ To remove Twilio credentials from a pool, set `encrypted_key` to `null`:
 ``` 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/custom-dialing-pools.mdx
+++ b/api-v1/post/custom-dialing-pools.mdx
@@ -187,4 +187,4 @@ Once you've created a custom dialing pool, you can use it in your call requests 
 The system will automatically select the most geographically appropriate phone number from your pool to maximize pickup rates. 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/delete_pathway.mdx
+++ b/api-v1/post/delete_pathway.mdx
@@ -47,4 +47,4 @@ description: "Delete your conversational pathway."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/guard-rails.mdx
+++ b/api-v1/post/guard-rails.mdx
@@ -201,4 +201,4 @@ Each attachment requires an `actions` array. Available action types:
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/inbound-insert.mdx
+++ b/api-v1/post/inbound-insert.mdx
@@ -62,4 +62,4 @@ description: "Add inbound numbers to Bland from your own Twilio account. See [Cu
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/inbound-number-delete.mdx
+++ b/api-v1/post/inbound-number-delete.mdx
@@ -43,4 +43,4 @@ description: "Remove an inbound number that was uploaded through your own Twilio
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/inbound-number-update.mdx
+++ b/api-v1/post/inbound-number-update.mdx
@@ -634,4 +634,4 @@ Example payloads:
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/inbound-purchase.mdx
+++ b/api-v1/post/inbound-purchase.mdx
@@ -41,4 +41,4 @@ description: "Purchase a new phone number (inbound/outbound). ($15/mo. subscript
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/inbound-session.mdx
+++ b/api-v1/post/inbound-session.mdx
@@ -92,4 +92,4 @@ Response:
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/inbound-update-label.mdx
+++ b/api-v1/post/inbound-update-label.mdx
@@ -104,4 +104,4 @@ description: "Update the label shown for one of your inbound phone numbers."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/knowledge-chat.mdx
+++ b/api-v1/post/knowledge-chat.mdx
@@ -107,4 +107,4 @@ Query a knowledge base using natural language and receive contextual responses. 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/knowledge-crawl.mdx
+++ b/api-v1/post/knowledge-crawl.mdx
@@ -105,4 +105,4 @@ curl -X POST https://api.bland.ai/v1/knowledge/crawl \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/knowledge-learn-file.mdx
+++ b/api-v1/post/knowledge-learn-file.mdx
@@ -163,4 +163,4 @@ curl -X POST https://api.bland.ai/v1/knowledge/learn \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/knowledge-learn-text.mdx
+++ b/api-v1/post/knowledge-learn-text.mdx
@@ -134,4 +134,4 @@ curl -X POST https://api.bland.ai/v1/knowledge/learn \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/knowledge-learn-web.mdx
+++ b/api-v1/post/knowledge-learn-web.mdx
@@ -164,4 +164,4 @@ curl -X POST https://api.bland.ai/v1/knowledge/learn \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/memory-contact.mdx
+++ b/api-v1/post/memory-contact.mdx
@@ -158,4 +158,4 @@ description: "Create a memory record for a contact scoped to a persona or agent 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/memory-create.mdx
+++ b/api-v1/post/memory-create.mdx
@@ -86,4 +86,4 @@ description: "Create a new memory to organize and track call interactions by pho
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/memory-enable.mdx
+++ b/api-v1/post/memory-enable.mdx
@@ -112,4 +112,4 @@ When memory is **disabled**, no new memory is written. Existing memory data is p
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/memory-memory-id-add-call.mdx
+++ b/api-v1/post/memory-memory-id-add-call.mdx
@@ -98,4 +98,4 @@ description: "Add an existing call to a memory."
 - Adding a call to a memory will automatically associate it with the phone number involved in the call
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/memory-memory-id-add-user.mdx
+++ b/api-v1/post/memory-memory-id-add-user.mdx
@@ -131,4 +131,4 @@ description: "Add a new user/phone number to an existing memory."
 - The summary will be enhanced over time as more calls are added to this user's record
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/memory-memory-id-call-call-id-delete.mdx
+++ b/api-v1/post/memory-memory-id-call-call-id-delete.mdx
@@ -82,4 +82,4 @@ description: "Remove a specific call from a memory."
 - The call itself is not deleted from your account, only its association with this memory is removed
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/memory-memory-id-delete.mdx
+++ b/api-v1/post/memory-memory-id-delete.mdx
@@ -64,4 +64,4 @@ This action is **irreversible**. Deleting a memory will permanently remove:
 Make sure you have backed up any important data before proceeding with deletion.
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/memory-memory-id-update.mdx
+++ b/api-v1/post/memory-memory-id-update.mdx
@@ -92,4 +92,4 @@ description: "Update the name of an existing memory."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/memory-memory-id-user-delete.mdx
+++ b/api-v1/post/memory-memory-id-user-delete.mdx
@@ -87,4 +87,4 @@ This action will permanently remove:
 The actual calls will remain in your account, but their association with this memory will be removed.
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/memory-memory-id-user-search.mdx
+++ b/api-v1/post/memory-memory-id-user-search.mdx
@@ -115,4 +115,4 @@ description: "Retrieve call history and data for a specific user/phone number wi
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/memory-memory-id-user-update.mdx
+++ b/api-v1/post/memory-memory-id-user-update.mdx
@@ -118,4 +118,4 @@ description: "Update the metadata and summary information for a specific user wi
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/memory-memory-id-user.mdx
+++ b/api-v1/post/memory-memory-id-user.mdx
@@ -117,4 +117,4 @@ description: "Retrieve detailed memory information for a specific user or phone 
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/memory-reset.mdx
+++ b/api-v1/post/memory-reset.mdx
@@ -66,4 +66,4 @@ This action is **irreversible**. All memory data (recent messages, summary, fact
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/move-pathway-folder.mdx
+++ b/api-v1/post/move-pathway-folder.mdx
@@ -37,4 +37,4 @@ description: "Moves a pathway to a different folder or to the root level."
 ```
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/node_test_invoke.mdx
+++ b/api-v1/post/node_test_invoke.mdx
@@ -128,4 +128,4 @@ description: "Start a node test run for a given node and pathway with a new prom
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/orgs.mdx
+++ b/api-v1/post/orgs.mdx
@@ -116,4 +116,4 @@ description: "Create a new organization."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/pathway-chat-create.mdx
+++ b/api-v1/post/pathway-chat-create.mdx
@@ -97,4 +97,4 @@ The specific version number of the pathway to use for this chat instance. If not
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/pathway-chat.mdx
+++ b/api-v1/post/pathway-chat.mdx
@@ -114,4 +114,4 @@ The message to send to the pathway (optional)
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/pathway-generate.mdx
+++ b/api-v1/post/pathway-generate.mdx
@@ -69,4 +69,4 @@ Use `GET /v1/pathway/generate/status/{job_id}` to start processing and poll unti
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/pathway-promote.mdx
+++ b/api-v1/post/pathway-promote.mdx
@@ -42,4 +42,4 @@ The version number of the pathway you want to promote
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/pathways.mdx
+++ b/api-v1/post/pathways.mdx
@@ -52,4 +52,4 @@ description: "Create a new conversational pathway"
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/personas-id-inbound-attach.mdx
+++ b/api-v1/post/personas-id-inbound-attach.mdx
@@ -111,4 +111,4 @@ description: "Attach one or more inbound phone numbers to a persona. The same en
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/personas-id-inbound-detach.mdx
+++ b/api-v1/post/personas-id-inbound-detach.mdx
@@ -77,4 +77,4 @@ description: "Detach one or more inbound phone numbers from a persona. Detached 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/personas-id-versions-promote.mdx
+++ b/api-v1/post/personas-id-versions-promote.mdx
@@ -143,4 +143,4 @@ description: "Promote a persona's draft version to production."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/personas.mdx
+++ b/api-v1/post/personas.mdx
@@ -210,4 +210,4 @@ description: "Create a new persona."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/postcall-webhooks-create.mdx
+++ b/api-v1/post/postcall-webhooks-create.mdx
@@ -91,4 +91,4 @@ Create and send post call webhooks for one or more call IDs. This endpoint allow
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/postcall-webhooks-resend.mdx
+++ b/api-v1/post/postcall-webhooks-resend.mdx
@@ -87,4 +87,4 @@ Resend post call webhooks for one or more call IDs. This endpoint allows you to 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/prompts.mdx
+++ b/api-v1/post/prompts.mdx
@@ -48,4 +48,4 @@ description: "Create and store a prompt for future use."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/sip-attach.mdx
+++ b/api-v1/post/sip-attach.mdx
@@ -166,4 +166,4 @@ curl -X POST https://api.bland.ai/v1/sip/attach \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/sip-detach.mdx
+++ b/api-v1/post/sip-detach.mdx
@@ -39,4 +39,4 @@ curl -X POST https://api.bland.ai/v1/sip/detach \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/sip-discover.mdx
+++ b/api-v1/post/sip-discover.mdx
@@ -100,4 +100,4 @@ curl -X POST https://api.bland.ai/v1/sip/discover \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/sip-port-document.mdx
+++ b/api-v1/post/sip-port-document.mdx
@@ -43,4 +43,4 @@ curl -X POST https://api.bland.ai/v1/sip/port/document \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/sip-port-initiate.mdx
+++ b/api-v1/post/sip-port-initiate.mdx
@@ -106,4 +106,4 @@ curl -X POST https://api.bland.ai/v1/sip/port/initiate \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/sip-test-call.mdx
+++ b/api-v1/post/sip-test-call.mdx
@@ -51,4 +51,4 @@ curl -X POST https://api.bland.ai/v1/sip/test-call \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/sip-update.mdx
+++ b/api-v1/post/sip-update.mdx
@@ -50,4 +50,4 @@ curl -X POST https://api.bland.ai/v1/sip/update \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/sms-analyze.mdx
+++ b/api-v1/post/sms-analyze.mdx
@@ -112,4 +112,4 @@ The ID of the SMS conversation to analyze.
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/sms-batch.mdx
+++ b/api-v1/post/sms-batch.mdx
@@ -170,4 +170,4 @@ phone_number,first_name,request_data.account_id
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/sms-create.mdx
+++ b/api-v1/post/sms-create.mdx
@@ -108,4 +108,4 @@ description: "Create an SMS conversation with specific pathway state without tri
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/sms-send.mdx
+++ b/api-v1/post/sms-send.mdx
@@ -169,4 +169,4 @@ This overrides the webhook for the conversation, instead of using the webhook at
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/sms-update.mdx
+++ b/api-v1/post/sms-update.mdx
@@ -158,4 +158,4 @@ description: "Update the SMS configuration for a phone number owned by the authe
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/speak.mdx
+++ b/api-v1/post/speak.mdx
@@ -413,4 +413,4 @@ response = requests.post(
 </ResponseExample> 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/tools-tool-id.mdx
+++ b/api-v1/post/tools-tool-id.mdx
@@ -329,4 +329,4 @@ description: "Change your Custom Tool's parameters and characteristics."
     
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/tools.mdx
+++ b/api-v1/post/tools.mdx
@@ -324,4 +324,4 @@ description: "Create a Custom Tool that can take AI input and call external APIs
     
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/update-pathway-version.mdx
+++ b/api-v1/post/update-pathway-version.mdx
@@ -71,4 +71,4 @@ description: "Updates a specific version of a pathway, including its version nam
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/update_pathway_folder.mdx
+++ b/api-v1/post/update_pathway_folder.mdx
@@ -43,4 +43,4 @@ description: "Updates the name of a specific folder for the authenticated user."
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/update_pathways.mdx
+++ b/api-v1/post/update_pathways.mdx
@@ -368,4 +368,4 @@ This example contains a complete car rental pathway with:
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/upload-media.mdx
+++ b/api-v1/post/upload-media.mdx
@@ -28,4 +28,4 @@ Upload media files along with optional metadata like name and description.
 </ParamField>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/upload-text.mdx
+++ b/api-v1/post/upload-text.mdx
@@ -28,4 +28,4 @@ Upload text files along with optional metadata like name and description.
 </ParamField>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/vectors.mdx
+++ b/api-v1/post/vectors.mdx
@@ -50,4 +50,4 @@ Usage: Pass the `vector_id` into your agent's `tools` to enable the agent to use
 </ResponseExample>
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/voices-id-sample.mdx
+++ b/api-v1/post/voices-id-sample.mdx
@@ -59,4 +59,4 @@ description: "Generate an audio sample for a voice."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/widget-custom-components.mdx
+++ b/api-v1/post/widget-custom-components.mdx
@@ -92,4 +92,4 @@ description: "Create a new custom component."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/widget-thread-webhook.mdx
+++ b/api-v1/post/widget-thread-webhook.mdx
@@ -144,4 +144,4 @@ curl -X POST "https://api.bland.ai/v1/widget/{widget_id}/threads/{thread_id}/web
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/widget.mdx
+++ b/api-v1/post/widget.mdx
@@ -90,4 +90,4 @@ description: "Creates a new widget."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/put/agent-testing-scenarios-id.mdx
+++ b/api-v1/put/agent-testing-scenarios-id.mdx
@@ -273,4 +273,4 @@ description: "Update an existing test scenario. If assertions are provided, they
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/put/knowledge-id.mdx
+++ b/api-v1/put/knowledge-id.mdx
@@ -151,4 +151,4 @@ curl -X PUT https://api.bland.ai/v1/knowledge/kb_01H8X9QK5R2N7P3M6Z8W4Y1V5T \
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v2/get/batches-id-logs.mdx
+++ b/api-v2/get/batches-id-logs.mdx
@@ -102,4 +102,4 @@ description: "Retrieve logs for a specific batch."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v2/get/batches-id.mdx
+++ b/api-v2/get/batches-id.mdx
@@ -74,4 +74,4 @@ description: "Retrieve metadata for a specific batch. This does not include logs
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v2/get/batches.mdx
+++ b/api-v2/get/batches.mdx
@@ -81,4 +81,4 @@ description: "Retrieve a list of all batches created by your organization."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v2/get/tools-logs-stats.mdx
+++ b/api-v2/get/tools-logs-stats.mdx
@@ -152,4 +152,4 @@ GET /v2/tools/logs/stats?group_by=integration,status&metrics=count,execution_tim
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v2/get/tools-logs.mdx
+++ b/api-v2/get/tools-logs.mdx
@@ -178,4 +178,4 @@ description: "Retrieve per-execution logs for your tools with optional filtering
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v2/get/tools.mdx
+++ b/api-v2/get/tools.mdx
@@ -161,4 +161,4 @@ description: "Retrieve a paginated list of your tools. Returns tools that are no
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v2/post/batches-id-stop.mdx
+++ b/api-v2/post/batches-id-stop.mdx
@@ -38,4 +38,4 @@ description: "Stop a batch that is currently running or scheduled."
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v2/post/batches.mdx
+++ b/api-v2/post/batches.mdx
@@ -136,4 +136,4 @@ We send one attempt per event with a 10-second timeout. If the request fails or 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v2/post/tools-tool-id.mdx
+++ b/api-v2/post/tools-tool-id.mdx
@@ -212,4 +212,4 @@ All fields are optional. Only fields included in the request body will be update
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v2/post/tools.mdx
+++ b/api-v2/post/tools.mdx
@@ -205,4 +205,4 @@ description: "Create a new tool. Tools connect to built-in integrations (e.g. Sl
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/enterprise-features/SIP-integration.mdx
+++ b/enterprise-features/SIP-integration.mdx
@@ -614,4 +614,4 @@ All SIP endpoints are under `/v1/sip` and require authentication via your API ke
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/enterprise-features/SSO.mdx
+++ b/enterprise-features/SSO.mdx
@@ -1030,4 +1030,4 @@ When contacting support, provide:
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/enterprise-features/citations.mdx
+++ b/enterprise-features/citations.mdx
@@ -143,4 +143,4 @@ Delay the main post-call webhook until citations are processed, then receive all
 > **Note:** For voice calls, citations are only processed on calls with a status of "completed". Calls that are unanswered, busy, or fail for other reasons will not generate citation data. For SMS conversations, citations are extracted when the conversation ends (via timeout, end-call node, or opt-out).
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/enterprise-features/custom-code-node.mdx
+++ b/enterprise-features/custom-code-node.mdx
@@ -113,4 +113,4 @@ These returned values (`processed_total`, `discount_applied`, `final_price`, `cu
 For additional questions or advanced use cases, please reach out to hello@bland.ai or through our support channels.
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/enterprise-features/custom-dialing.mdx
+++ b/enterprise-features/custom-dialing.mdx
@@ -23,4 +23,4 @@ Custom dialing pools can now be accessed via the [API](/api-v1/get/custom-dialin
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/enterprise-features/infrastructure-and-releases.mdx
+++ b/enterprise-features/infrastructure-and-releases.mdx
@@ -132,4 +132,4 @@ Combined with dedicated infrastructure and version-pinned releases, this gives y
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/enterprise-features/jwt-authentication.mdx
+++ b/enterprise-features/jwt-authentication.mdx
@@ -214,4 +214,4 @@ Rate limit cache refreshes to prevent DoS attacks (minimum 5 seconds between ref
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/enterprise-features/scheduling-node.mdx
+++ b/enterprise-features/scheduling-node.mdx
@@ -96,4 +96,4 @@ For any additional questions, please reach out to hello@bland.ai or any other su
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/enterprise-features/studio-flow-integration.mdx
+++ b/enterprise-features/studio-flow-integration.mdx
@@ -31,4 +31,4 @@ This will transition the call to Bland from a studio flow. To transition out of 
 2. Follow the instructons in the studio flow node to complete the full setup.
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/platform/billing.mdx
+++ b/platform/billing.mdx
@@ -187,4 +187,4 @@ Your current credit balance, usage history, and purchase options are all visible
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/sdks/cli.mdx
+++ b/sdks/cli.mdx
@@ -305,4 +305,4 @@ Profiles are stored at `~/.config/bland-cli/config.json`. You can also override 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/sdks/dev-terminal.mdx
+++ b/sdks/dev-terminal.mdx
@@ -70,4 +70,4 @@ bland guide variables        # Extracting and using caller data
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/sdks/web-agent-sdk.mdx
+++ b/sdks/web-agent-sdk.mdx
@@ -98,4 +98,4 @@ function AgentWidget({ agentId }) {
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/batch-calls.mdx
+++ b/tutorials/batch-calls.mdx
@@ -168,4 +168,4 @@ The agent will automatically personalize each call using the values from that ro
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/blocked-numbers.mdx
+++ b/tutorials/blocked-numbers.mdx
@@ -94,4 +94,4 @@ You can programmatically manage blocked numbers using our API.
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/btts.mdx
+++ b/tutorials/btts.mdx
@@ -142,4 +142,4 @@ Punctuation directly affects speech delivery in BTTS v2:
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/call-logs.mdx
+++ b/tutorials/call-logs.mdx
@@ -212,4 +212,4 @@ The context panel contains collapsible detail sections. Use the expand/collapse 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/chat-widget.mdx
+++ b/tutorials/chat-widget.mdx
@@ -289,4 +289,4 @@ When a conversation ends, Bland sends a POST request to your configured webhook 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/custom-twilio.mdx
+++ b/tutorials/custom-twilio.mdx
@@ -53,4 +53,4 @@ Note:
 Note: When updating inbound numbers, the headers need to include the `encrypted_key` in addition to the `Authorization` header. Doing so makes sure the updates are applied to the correct Twilio account.
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/guard-rails.mdx
+++ b/tutorials/guard-rails.mdx
@@ -84,4 +84,4 @@ Once satisfied, you can save the guard rail and apply it to any persona, pathway
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/memories.mdx
+++ b/tutorials/memories.mdx
@@ -193,4 +193,4 @@ For standard use, you do not need to manage any IDs directly. Enable memory on y
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/outcomes.mdx
+++ b/tutorials/outcomes.mdx
@@ -88,4 +88,4 @@ Reach out to your enterprise account manager or [contact our team](https://forms
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/pathways.mdx
+++ b/tutorials/pathways.mdx
@@ -342,4 +342,4 @@ If you have any additional questions, reach out on our [Discord](https://discord
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/personas.mdx
+++ b/tutorials/personas.mdx
@@ -229,4 +229,4 @@ When using `persona_id` in API calls:
 - This allows for flexible, context-specific customization while maintaining consistency
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/post-call-webhooks.mdx
+++ b/tutorials/post-call-webhooks.mdx
@@ -580,4 +580,4 @@ The following error messages appear in the `error_message` field within successf
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/scenarios.mdx
+++ b/tutorials/scenarios.mdx
@@ -253,4 +253,4 @@ For full endpoint details, see the [Scenarios API Reference](/api-v1/post/agent-
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/secrets.mdx
+++ b/tutorials/secrets.mdx
@@ -106,4 +106,4 @@ Additionally, you can use your secrets in your custom tools.
 * Rotate static secrets regularly
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/sms.mdx
+++ b/tutorials/sms.mdx
@@ -299,4 +299,4 @@ For webhooks, delivery status, and number updates, see the **Messaging** section
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/standards.mdx
+++ b/tutorials/standards.mdx
@@ -68,4 +68,4 @@ Each standard executes and evaluates ten scenarios, tallies the total number of 
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/testbed.mdx
+++ b/tutorials/testbed.mdx
@@ -109,4 +109,4 @@ Publishing both creates a [Standard](/tutorials/standards) and publishes your pr
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/tools.mdx
+++ b/tutorials/tools.mdx
@@ -161,4 +161,4 @@ You can insert a custom tool node directly into your pathway:
 />
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/v2-tools-built-in.mdx
+++ b/tutorials/v2-tools-built-in.mdx
@@ -138,4 +138,4 @@ Route your pathway based on what the tool returned:
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/v2-tools-custom-api.mdx
+++ b/tutorials/v2-tools-custom-api.mdx
@@ -253,4 +253,4 @@ Example:
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/v2-tools.mdx
+++ b/tutorials/v2-tools.mdx
@@ -267,4 +267,4 @@ Manage tools programmatically using the Tools API:
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/warm-transfer.mdx
+++ b/tutorials/warm-transfer.mdx
@@ -360,4 +360,4 @@ Each attempt to reach an agent has its own state in the `proxy_agent_calls` arra
 For additional support, reach out to your customer success representative, our [support email](mailto:hello@bland.ai), or [Discord](https://discord.gg/QvxDz8zcKe).
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/webhook-signing.mdx
+++ b/tutorials/webhook-signing.mdx
@@ -51,4 +51,4 @@ app.post('/webhook', (req, res) => {
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/webhooks.mdx
+++ b/tutorials/webhooks.mdx
@@ -178,4 +178,4 @@ Enable the agent to speak while the webhook is processing:
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)

--- a/welcome-to-bland.mdx
+++ b/welcome-to-bland.mdx
@@ -61,4 +61,4 @@ We're glad to have you here - go build something Bland.
 
 ---
 
-Docs for agents: [llm.txt](/llm.txt)
+Docs for agents: [llms.txt](/llms.txt)


### PR DESCRIPTION
## Summary

Every API reference, tutorial, enterprise feature, and SDK page links to `/llm.txt` (singular) in its "Docs for agents:" footer. The redirect in `docs.json` from `/llm.txt → /llms.txt` does not fire on Mintlify (`/llm.txt` currently 404s; `/llms.txt` 200s with the full file).

`llms.txt` (plural) is the community standard at https://llmstxt.org. The new quickstart already uses the correct `/llms.txt` form. This PR brings the remaining 282 pages in line.

## What changed

Single mechanical find/replace across all `.mdx` files:

```
[llm.txt](/llm.txt) → [llms.txt](/llms.txt)
```

Diff shape: **282 files changed, 282 insertions(+), 282 deletions(-)**. One line per file, no other content touched.

The `/llm.txt → /llms.txt` redirect entry in `docs.json` stays in place as a safety net for any external inbound links that point at the wrong path.

## Test plan

- [ ] Mintlify preview deploys cleanly
- [ ] Spot-check 3 random pages (e.g. `/sdks/cli`, `/tutorials/pathways`, `/api-v1/get/calls`) — footer "Docs for agents:" link goes to `/llms.txt` and returns 200
- [ ] No content other than the footer link changed (the diff is uniform)

## Companions

- #207 — `feat/quickstart-rewrite` (three-path quickstart restructure)
- `feat/aeo-tier1-cleanup` — descriptions, redirects, robots, welcome lead (sibling AEO PR)
