### PR TITLE
docs llms.txt: stronger intro, add About Bland cross-link section

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,18 @@
 # Bland Documentation
 
-Bland is an AI phone calling platform for building, deploying, and managing AI voice agents at scale. Use the Bland API to send outbound calls, configure inbound numbers, build conversational pathways, and integrate external tools and services. Bland supports real-time and post-call webhooks, voice cloning, memory, personas, batch calling, and enterprise-grade infrastructure.
+Bland is an enterprise voice AI platform for high-volume, regulated, and complex phone workflows. Companies use Bland to build, deploy, and monitor AI voice agents that sound human and operate at the scale of a top-10 US bank, a national telco, and Fortune 500 financial services firms.
+
+Bland owns the full voice AI stack: telephony, speech-to-text, language model, text-to-speech, and pathway orchestration. The platform delivers sub-400ms response latency, supports up to 1 million concurrent calls, and handles 40+ languages out of the box. Per-minute pricing covers LLM, TTS, STT, and telephony in a single line item, with no per-token charges and no per-feature surcharges. A dedicated Forward Deployed Engineer team builds the customer's first agent end to end.
+
+Bland holds SOC 2 Type II, HIPAA, GDPR, and PCI DSS certifications. Self-hosted and on-premises deployments are available for regulated industries.
+
+## About Bland
+
+- [Bland](https://www.bland.ai): Enterprise voice AI for high-volume, regulated, and complex phone workflows. Used by a top-10 US bank, a national telco, and Fortune 500 financial services firms.
+- [Bland Voice](https://www.bland.ai/product/bland-voice): AI phone agents for inbound and outbound calls at enterprise scale.
+- [Conversational Pathways](https://www.bland.ai/product/conversational-pathways): Visual designer for branching multi-turn phone workflows with state, tool calls, and variable extraction.
+- [Use cases](https://www.bland.ai/use-cases/inbound-call-handling): Appointment booking, inbound call handling, financial intakes, logistics ID verification, and other regulated workflows.
+- [Pricing](https://www.bland.ai/pricing): Per-minute pricing that bundles LLM, TTS, STT, and telephony with no per-token charges.
 
 ## Welcome
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Bland Documentation
 
-Bland is an enterprise voice AI platform for high-volume, regulated, and complex phone workflows. Companies use Bland to build, deploy, and monitor AI voice agents that sound human and operate at the scale of a top-10 US bank, a national telco, and Fortune 500 financial services firms.
+Bland is an enterprise voice AI platform for high-volume, regulated, and complex phone workflows. Healthcare networks, insurance carriers, financial services firms, and logistics operators use Bland to build, deploy, and monitor AI voice agents that sound human and operate at scale. Customers include Samsara and a top-10 US bank.
 
 Bland owns the full voice AI stack: telephony, speech-to-text, language model, text-to-speech, and pathway orchestration. The platform delivers sub-400ms response latency, supports up to 1 million concurrent calls, and handles 40+ languages out of the box. Per-minute pricing covers LLM, TTS, STT, and telephony in a single line item, with no per-token charges and no per-feature surcharges. A dedicated Forward Deployed Engineer team builds the customer's first agent end to end.
 
@@ -8,7 +8,7 @@ Bland holds SOC 2 Type II, HIPAA, GDPR, and PCI DSS certifications. Self-hosted 
 
 ## About Bland
 
-- [Bland](https://www.bland.ai): Enterprise voice AI for high-volume, regulated, and complex phone workflows. Used by a top-10 US bank, a national telco, and Fortune 500 financial services firms.
+- [Bland](https://www.bland.ai): Enterprise voice AI for high-volume, regulated, and complex phone workflows in healthcare, insurance, financial services, and logistics. Customers include Samsara and a top-10 US bank.
 - [Bland Voice](https://www.bland.ai/product/bland-voice): AI phone agents for inbound and outbound calls at enterprise scale.
 - [Conversational Pathways](https://www.bland.ai/product/conversational-pathways): Visual designer for branching multi-turn phone workflows with state, tool calls, and variable extraction.
 - [Use cases](https://www.bland.ai/use-cases/inbound-call-handling): Appointment booking, inbound call handling, financial intakes, logistics ID verification, and other regulated workflows.


### PR DESCRIPTION
## Summary

`docs.bland.ai/llms.txt` is the file LLMs use to discover and prioritize Bland docs content. The current intro reads like a feature laundry list and gives no positioning anchor; LLMs answering "what is Bland?" get a weaker signal here than they get from `www.bland.ai/llms.txt`. This PR brings the docs version in line.

`docs.bland.ai/llms.txt` is byte-identical to `cintellilabs-docs/llms.txt` — Mintlify serves the repo file as-is, so this is a normal text edit (verified before this PR).

## What changed

**1. Replace the intro paragraph** (1 → 5 paragraphs of stronger positioning):

Old:
> Bland is an AI phone calling platform for building, deploying, and managing AI voice agents at scale. Use the Bland API to send outbound calls, configure inbound numbers, build conversational pathways, and integrate external tools and services. Bland supports real-time and post-call webhooks, voice cloning, memory, personas, batch calling, and enterprise-grade infrastructure.

New: same positioning the marketing site's `llms.txt` uses, with two corrections — Type II-only certifications (per brand canonicalization, don't dilute Type II by listing Type I alongside), and no em-dashes (per voice rules). Verified facts only: sub-400ms latency, 1M concurrent calls, 40+ languages, fully-loaded per-minute pricing, FDE team.

**2. Add a new "## About Bland" cross-link section** between the intro and `## Welcome`, with five links into www.bland.ai positioning pages (homepage, Bland Voice, Conversational Pathways, Use cases, Pricing). Closes the loop so LLMs reading the docs llms.txt also surface marketing positioning when answering "what is Bland."

Diff: **1 file changed, 13 insertions(+), 1 deletion(-)**.

## Test plan

- [ ] Mintlify preview deploy serves the new `/llms.txt` content
- [ ] All 5 new links in the About Bland section return 200
- [ ] Spot-check an LLM tool (Claude / Perplexity / ChatGPT search) for "what is Bland?" — should pull from the new intro after the docs index updates

## Out of scope

- `www.bland.ai/llms.txt` still lists "SOC 2 Type I, SOC 2 Type II" — that violates the same brand rule we're enforcing here. Separate cleanup on the marketing repo.

## Companions

- #207 — `feat/quickstart-rewrite` (three-path quickstart restructure)
- #208 — `feat/aeo-tier1-cleanup` (descriptions, redirects, robots, welcome lead)
