### PR TITLE
docs: document Persona + KB attachment, clarify Persona vs Web Agent boundary

### DIFF
--- a/api-v1/patch/personas-id.mdx
+++ b/api-v1/patch/personas-id.mdx
@@ -4,6 +4,10 @@ api: "PATCH https://api.bland.ai/v1/personas/{persona_id}"
 description: "Update an existing persona configuration."
 ---
 
+<Info>
+  **Updates write to the draft, not production.** This endpoint stages changes in `current_draft_version`. Live inbound and SMS calls keep using `current_production_version` until you promote the draft with [Promote Version](/api-v1/post/personas-id-versions-promote).
+</Info>
+
 ### Headers
 
 <ParamField header="authorization" type="string" required>
@@ -63,6 +67,9 @@ description: "Update an existing persona configuration."
     <ParamField body="interruption_threshold" type="number">
       Interruption sensitivity threshold.
     </ParamField>
+    <ParamField body="first_sentence" type="string">
+      Phrase the agent says first instead of generating a greeting on the fly. Must be under 200 characters.
+    </ParamField>
   </Expandable>
 </ParamField>
 
@@ -101,7 +108,9 @@ description: "Update an existing persona configuration."
 </ParamField>
 
 <ParamField body="kb_ids" type="array">
-  Updated array of knowledge base IDs to connect to the persona.
+  Replacement array of knowledge base UUIDs for the persona. Pass the full set you want attached; omitted IDs will be detached on the draft.
+
+  IDs come from [Upload Text](/api-v1/post/knowledge-learn-text), [Upload File](/api-v1/post/knowledge-learn-file), or [Crawl Web](/api-v1/post/knowledge-learn-web). The same knowledge base can be attached to multiple personas. Changes only affect live calls after the draft is promoted.
 </ParamField>
 
 ### Response

--- a/api-v1/post/agents.mdx
+++ b/api-v1/post/agents.mdx
@@ -4,6 +4,8 @@ api: "POST https://api.bland.ai/v1/agents"
 description: "Configure all of the settings for a new web agent."
 ---
 
+Web Agents power **embedded browser voice and chat** via the [`@blandsdk/client`](/sdks/cli) library. They are configured directly on `/v1/agents` and authorized per-session through [`/v1/agents/{id}/authorize`](/api-v1/post/agents-id-authorize). For inbound phone numbers or SMS, use [Personas](/api-v1/post/personas) instead; see [Personas vs. Web Agents](/tutorials/personas#personas-vs-web-agents) for the full comparison.
+
 ### Headers
 
 <ParamField header="authorization" type="string" required>
@@ -144,9 +146,18 @@ document.addEventListener('DOMContentLoaded', async () => {
 </ParamField>
 
 <ParamField body="tools" type="array">
-  Interact with the real world through API calls.
+  Interact with the real world through API calls, and attach knowledge bases for retrieval during the call. The array accepts both tool IDs and knowledge base UUIDs.
 
-  Detailed tutorial here: [Custom Tools](/tutorials/custom-tools)
+  ```json
+  {
+    "tools": [
+      "TL-ba6c4237-67c2-40e8-868b-60d429a84eda",
+      "389abfee-3a07-4dfb-be71-91c9c3705704"
+    ]
+  }
+  ```
+
+  Knowledge base UUIDs come from [Upload Text](/api-v1/post/knowledge-learn-text), [Upload File](/api-v1/post/knowledge-learn-file), or [Crawl Web](/api-v1/post/knowledge-learn-web). See the [attachment matrix](/api-v1/post/knowledge-learn-text#where-can-a-knowledge-base-be-attached) for the other surfaces that consume the same UUID. Detailed tools tutorial: [Custom Tools](/tutorials/custom-tools).
 </ParamField>
 
 <ParamField body="dynamic_data" type="object">

--- a/api-v1/post/knowledge-learn-file.mdx
+++ b/api-v1/post/knowledge-learn-file.mdx
@@ -6,6 +6,8 @@ description: "Creates a new knowledge base by uploading a file."
 
 Upload a file to create a knowledge base that can be used to provide contextual information to your AI agents. Supported file formats include PDF, Word documents, text files, and more.
 
+This endpoint returns a `data.id` UUID. See [Where can a knowledge base be attached?](/api-v1/post/knowledge-learn-text#where-can-a-knowledge-base-be-attached) for the surfaces that consume the UUID (Web Agents, Personas, Pathway nodes, outbound calls).
+
 ### Headers
 
 <ParamField header="authorization" type="string" required>

--- a/api-v1/post/knowledge-learn-text.mdx
+++ b/api-v1/post/knowledge-learn-text.mdx
@@ -6,6 +6,20 @@ description: "Creates a new knowledge base from direct text input."
 
 Create a knowledge base by providing text content directly in the request. This is ideal for when you have structured text content that you want to make searchable for your AI agents.
 
+This endpoint returns a `data.id` UUID. Plug that UUID into any of the surfaces below to make the knowledge base available on a call. The same UUID can be attached to as many places as you want; the relationship is many-to-many.
+
+### Where can a knowledge base be attached?
+
+| Surface | How to attach | Notes |
+| --- | --- | --- |
+| **Web Agent** (browser SDK) | [`POST /v1/agents`](/api-v1/post/agents) or [`POST /v1/agents/{id}`](/api-v1/post/agents-id), `tools: ["<kb_uuid>"]` | The `tools` array accepts knowledge base UUIDs and tool IDs interchangeably. |
+| **Inbound phone number** | [`POST /v1/personas`](/api-v1/post/personas) or [`PATCH /v1/personas/{id}`](/api-v1/patch/personas-id), `kb_ids: ["<kb_uuid>"]`, then [attach the number](/api-v1/post/personas-id-inbound-attach) | Updates land on the draft; [promote](/api-v1/post/personas-id-versions-promote) before the change is live. |
+| **SMS / iMessage** | Same as inbound phone: set `kb_ids` on the persona, then attach the SMS-capable number | Channel capability follows the number's own configuration. |
+| **Pathway node** | Configure the knowledge base on the node in the pathway builder | See [Pathways](/tutorials/pathways). Nodes hold their own KB list. |
+| **Outbound call** | [`POST /v1/calls`](/api-v1/post/calls), `tools: ["<kb_uuid>"]` | Same array as Web Agents. If `persona_id` is set, the persona's `kb_ids` apply and `tools` adds to them. |
+
+Legacy `KB-` prefixed vector store IDs are no longer issued. Existing `KB-` IDs still resolve, but new knowledge bases use UUIDs.
+
 ### Headers
 
 <ParamField header="authorization" type="string" required>

--- a/api-v1/post/knowledge-learn-web.mdx
+++ b/api-v1/post/knowledge-learn-web.mdx
@@ -6,6 +6,8 @@ description: "Creates a new knowledge base by scraping content from web URLs."
 
 Create a knowledge base by scraping content from one or more web URLs. This is perfect for creating knowledge bases from documentation sites, blog posts, or other web-based content.
 
+This endpoint returns a `data.id` UUID. See [Where can a knowledge base be attached?](/api-v1/post/knowledge-learn-text#where-can-a-knowledge-base-be-attached) for the surfaces that consume the UUID (Web Agents, Personas, Pathway nodes, outbound calls).
+
 ### Headers
 
 <ParamField header="authorization" type="string" required>

--- a/api-v1/post/personas-id-inbound-attach.mdx
+++ b/api-v1/post/personas-id-inbound-attach.mdx
@@ -1,8 +1,12 @@
 ---
 title: "Attach Phone Numbers to Persona"
 api: "POST https://api.bland.ai/v1/personas/{persona_id}/inbound/attach"
-description: "Attach one or more inbound phone numbers to a persona. The same endpoint handles voice, SMS, and WhatsApp numbers — channel capability is determined by the number's own configuration, not by this call."
+description: "Attach one or more inbound phone numbers to a persona. The same endpoint handles voice, SMS, and WhatsApp numbers; channel capability is determined by the number's own configuration, not by this call."
 ---
+
+<Note>
+  Once a number is attached, every inbound call or message it receives uses the persona's `current_production_version`, including any knowledge bases listed in the persona's `kb_ids`. Update the knowledge attachment via [Update Persona](/api-v1/patch/personas-id) and promote the draft to make the change live.
+</Note>
 
 ### Headers
 

--- a/api-v1/post/personas.mdx
+++ b/api-v1/post/personas.mdx
@@ -4,6 +4,12 @@ api: "POST https://api.bland.ai/v1/personas"
 description: "Create a new persona."
 ---
 
+Personas are reusable agent configurations for **inbound phone numbers** and **SMS**. Once created, attach a persona to one or more numbers with [Attach Phone Numbers to Persona](/api-v1/post/personas-id-inbound-attach). For embedded **browser** voice agents, use [Create a Web Agent](/api-v1/post/agents) instead. See [Personas vs. Web Agents](/tutorials/personas#personas-vs-web-agents) for the full comparison.
+
+<Info>
+  **Draft / production split.** Creating a persona writes the initial configuration to both `current_production_version` and `current_draft_version` and auto-promotes it. Any later [Update Persona](/api-v1/patch/personas-id) call writes only to the draft; the draft must be promoted with [Promote Version](/api-v1/post/personas-id-versions-promote) before it affects live calls.
+</Info>
+
 ### Headers
 
 <ParamField header="authorization" type="string" required>
@@ -57,6 +63,9 @@ description: "Create a new persona."
     <ParamField body="interruption_threshold" type="number">
       Interruption sensitivity threshold.
     </ParamField>
+    <ParamField body="first_sentence" type="string">
+      Phrase the agent says first instead of generating a greeting on the fly. Must be under 200 characters.
+    </ParamField>
   </Expandable>
 </ParamField>
 
@@ -95,8 +104,49 @@ description: "Create a new persona."
 </ParamField>
 
 <ParamField body="kb_ids" type="array">
-  Array of knowledge base IDs to connect to the persona.
+  Array of knowledge base UUIDs to attach to the persona. The agent retrieves from these knowledge bases on every call routed through this persona, on both voice and SMS channels.
+
+  IDs come from [Upload Text](/api-v1/post/knowledge-learn-text), [Upload File](/api-v1/post/knowledge-learn-file), or [Crawl Web](/api-v1/post/knowledge-learn-web). Use the `data.id` returned by those endpoints. The relationship is many-to-many: one knowledge base can be referenced from any number of personas.
+
+  Legacy `KB-` prefixed vector store IDs are no longer issued. Existing `KB-` IDs still resolve for backward compatibility, but new knowledge bases use UUIDs.
 </ParamField>
+
+### Request Example
+
+<RequestExample>
+```bash cURL
+curl -X POST https://api.bland.ai/v1/personas \
+  -H "authorization: YOUR_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{
+    "name": "Support persona",
+    "personality_prompt": "You are a helpful support agent for Acme Corp. Be concise and friendly.",
+    "call_config": {
+      "voice": "june",
+      "first_sentence": "Hi, this is Acme support. How can I help?",
+      "interruption_threshold": 100
+    },
+    "kb_ids": [
+      "389abfee-3a07-4dfb-be71-91c9c3705704"
+    ]
+  }'
+```
+
+```json Request Body
+{
+  "name": "Support persona",
+  "personality_prompt": "You are a helpful support agent for Acme Corp. Be concise and friendly.",
+  "call_config": {
+    "voice": "june",
+    "first_sentence": "Hi, this is Acme support. How can I help?",
+    "interruption_threshold": 100
+  },
+  "kb_ids": [
+    "389abfee-3a07-4dfb-be71-91c9c3705704"
+  ]
+}
+```
+</RequestExample>
 
 ### Response
 

--- a/tutorials/personas.mdx
+++ b/tutorials/personas.mdx
@@ -5,7 +5,24 @@ description: "Create unified AI agents that manage all your phone numbers and us
 
 ## Introduction
 
-Personas are unified AI agents that manage all your phone numbers and use cases in one place. Instead of configuring each phone number separately with different prompts and settings, create a single intelligent persona that handles everything - from smart call routing to maintaining consistent personality across all interactions.
+Personas are reusable agent configurations for **inbound phone numbers** and **SMS / iMessage**. Instead of configuring each phone number separately with different prompts and settings, create one persona and attach it to any number that should answer the same way.
+
+For embedded **browser** voice or chat (the `@blandsdk/client` widget), use [Web Agents](/api-v1/post/agents) instead. The two systems are parallel, not nested; see [Personas vs. Web Agents](#personas-vs-web-agents) below.
+
+## Personas vs. Web Agents
+
+Both objects are commonly called "agents", but they are distinct primitives with different APIs and different surfaces.
+
+|  | Personas | Web Agents |
+| --- | --- | --- |
+| **Use case** | Inbound phone, outbound phone, SMS, iMessage | Embedded browser voice and chat |
+| **Create endpoint** | [`POST /v1/personas`](/api-v1/post/personas) | [`POST /v1/agents`](/api-v1/post/agents) |
+| **Attaches to** | Phone numbers via [`/personas/{id}/inbound/attach`](/api-v1/post/personas-id-inbound-attach); outbound calls via the `persona_id` param on [`/v1/calls`](/api-v1/post/calls) | Browser sessions via [`@blandsdk/client`](/sdks/cli), authorized through [`/v1/agents/{id}/authorize`](/api-v1/post/agents-id-authorize) |
+| **Knowledge bases** | Attached via the persona's `kb_ids` array | Attached via the agent's `tools` array (mixed with tool IDs) |
+| **Draft / production** | Yes; updates land on a draft and must be promoted | No; updates take effect immediately |
+| **Routing** | `pathway_conditions` choose between pathways inside the persona | One agent, one pathway at a time |
+
+There is no `persona_id` field on `POST /v1/agents`, and no Web Agent authorize endpoint on `/v1/personas/{id}`. Personas and Web Agents do not wrap each other.
 
 <CardGroup cols={2}>
   <Card title="Smart Routing" icon="route">
@@ -24,7 +41,7 @@ Personas are unified AI agents that manage all your phone numbers and use cases 
     Apply one persona across multiple phone numbers, or use different personas for specific use cases.
   </Card>
   <Card title="API Compatible" icon="code">
-    Use personas programmatically through the `persona_id` parameter in your API calls.
+    Reference a persona on outbound calls with the `persona_id` parameter on [`POST /v1/calls`](/api-v1/post/calls).
   </Card>
 </CardGroup>
 
@@ -61,8 +78,8 @@ Define your persona's identity, voice settings, and communication channels.
 - **Background Noise**: Add ambient sounds like "Office-style soundscape" with typing, chatter, and office sounds
 - **Modalities**: Configure communication channels:
   - Voice & Calls (with "Add to Inbound Numbers" integration)
-  - SMS Messaging (coming soon)
-  - Web Widget (coming soon)
+  - SMS and iMessage (via SMS-capable numbers attached to the persona)
+  - Embedded browser voice is **not** a persona modality. Use a [Web Agent](/api-v1/post/agents) instead.
 
 ### Behavior Configuration
 
@@ -91,7 +108,7 @@ Configure your persona's conversational behavior and routing logic.
 
 ### Knowledge Integration
 
-Connect your persona to knowledge bases for intelligent information retrieval.
+Connect your persona to knowledge bases for intelligent information retrieval. Knowledge bases attached here run on every inbound call and SMS routed through the persona.
 
 <img style={{ borderRadius: "0.5rem" }} src="/tutorials/tutorials-assets/personas/persona_knowledge.jpeg" />
 
@@ -102,6 +119,8 @@ Connect your persona to knowledge bases for intelligent information retrieval.
 - **Continuous Learning** (Coming Soon):
   - Question & Answer Improvements
   - Conversational Memory
+
+Via the API, the same attachment happens through the `kb_ids` array on [`POST /v1/personas`](/api-v1/post/personas) or [`PATCH /v1/personas/{id}`](/api-v1/patch/personas-id). The IDs are UUIDs returned by [`POST /v1/knowledge/learn`](/api-v1/post/knowledge-learn-text). One knowledge base can be attached to any number of personas.
 
 ### Analysis & Webhooks
 


### PR DESCRIPTION
## Summary

Closes documentation gaps around how Bland Knowledge Bases attach to Personas, and clarifies the model boundary between **Personas** (inbound phone, SMS, iMessage) and **Web Agents** (embedded browser voice/chat via `@blandsdk/client`). Findings come from a live test session against `api.bland.ai` on 2026-05-11.

> **Sibling PR.** This pairs with the planned `docs: deprecate /v1/vectors, document /v1/knowledge/learn as canonical` PR. If that PR is open when this one is reviewed, land them together; if it ships first, this PR's UUID-based wording is already aligned with it.

## Verified facts (from live API testing, 2026-05-11)

1. `POST /v1/personas` accepts: `name`, `role`, `description`, `tags`, `image_url`, `call_config` (voice, language, max_duration, wait_for_greeting, interruption_threshold, first_sentence, record, background), `orchestration_prompt`, `personality_prompt`, `default_tools`, `pathway_conditions`, `kb_ids`. Returns `data.id` (UUID) plus auto-created `current_production_version` and `current_draft_version`.
2. `kb_ids` is many-to-many. One KB can be referenced from many Personas. Values are UUIDs from `POST /v1/knowledge/learn`. Legacy `KB-` prefixed IDs are no longer issued.
3. Personas and Web Agents are parallel, not nested. `POST /v1/agents` has no `persona_id` field; `GET /v1/agents/{persona_uuid}/authorize` returns Agent Not Found; `POST /v1/personas/{id}/authorize` returns 404. Personas attach only to inbound phone numbers and SMS.
4. Web Agents attach KBs via the `tools` array. `PATCH /v1/agents/{id}` with `tools: ["<kb_uuid>"]` persists and reads back on GET.
5. The `@blandsdk/client` browser SDK is hardcoded to `agentId`. No persona path exists in the SDK.
6. Personas have a draft/production split. `POST /v1/personas` auto-promotes the initial config; subsequent `PATCH` lands on the draft and must be explicitly promoted.

## File-by-file changes

- **`api-v1/post/personas.mdx`** — Lead with a one-line scoping statement (inbound phone + SMS), Info callout on draft/production behavior, `kb_ids` expanded to explain UUID source and many-to-many semantics, `first_sentence` added to `call_config`, full request example with `kb_ids`.
- **`api-v1/patch/personas-id.mdx`** — Info callout that updates write to the draft, `kb_ids` description clarified (replacement set; promote to go live), `first_sentence` added to `call_config`.
- **`api-v1/post/personas-id-inbound-attach.mdx`** — Note that attached numbers inherit the persona's `kb_ids` and follow its production version.
- **`api-v1/post/knowledge-learn-text.mdx`** — New "Where can a knowledge base be attached?" matrix covering Web Agent, inbound phone, SMS/iMessage, Pathway node, and outbound call. Legacy `KB-` note.
- **`api-v1/post/knowledge-learn-file.mdx`** — Cross-link to the matrix.
- **`api-v1/post/knowledge-learn-web.mdx`** — Cross-link to the matrix.
- **`api-v1/post/agents.mdx`** — Scoping paragraph (Web Agents are for browser sessions only, link to Personas vs Web Agents). `tools` field expanded to explain it accepts both tool IDs and KB UUIDs, with an example.
- **`tutorials/personas.mdx`** — New "Personas vs. Web Agents" comparison table. Removed misleading "Web Widget (coming soon)" modality and the over-broad "API Compatible" claim. Knowledge Integration section now explains the API mapping (`kb_ids` array of UUIDs).

## Persona create example with `kb_ids`

```json
POST /v1/personas
{
  "name": "Support persona",
  "personality_prompt": "You are a helpful support agent for Acme Corp.",
  "call_config": {
    "voice": "june",
    "first_sentence": "Hi, this is Acme support. How can I help?",
    "interruption_threshold": 100
  },
  "kb_ids": [
    "389abfee-3a07-4dfb-be71-91c9c3705704"
  ]
}
```

## Attachment matrix (now rendered in `knowledge-learn-text.mdx`)

| Surface | How to attach | Notes |
| --- | --- | --- |
| Web Agent (browser SDK) | `POST /v1/agents` or `POST /v1/agents/{id}`, `tools: ["<kb_uuid>"]` | `tools` accepts KB UUIDs and tool IDs interchangeably. |
| Inbound phone number | Persona `kb_ids`, then attach number | Updates land on the draft; promote to go live. |
| SMS / iMessage | Persona `kb_ids` with SMS-capable number attached | Channel follows the number's configuration. |
| Pathway node | Configure on the node in the pathway builder | Nodes hold their own KB list. |
| Outbound call | `POST /v1/calls`, `tools: ["<kb_uuid>"]` | If `persona_id` is set, the persona's `kb_ids` also apply. |

## Test plan

- [ ] Mintlify broken-link check stays clean for the touched files (verified locally; the 10 broken links surfaced live in pre-existing unrelated files, none in this PR's files).
- [ ] Preview build renders the new `## Personas vs. Web Agents` heading in `tutorials/personas.mdx` and resolves the `#personas-vs-web-agents` in-page anchors used from `api-v1/post/personas.mdx` and `api-v1/post/agents.mdx`.
- [ ] Preview build renders the new `### Where can a knowledge base be attached?` section in `knowledge-learn-text.mdx` and resolves the `#where-can-a-knowledge-base-be-attached` anchor used from the other knowledge create pages and from `agents.mdx`.
- [ ] Spot-check the new request example renders with proper code-block highlighting.

Generated with Claude Code (https://claude.com/claude-code)
