### PR TITLE
docs: add KB attachment matrix across surfaces

### DIFF
--- a/api-v1/post/agents.mdx
+++ b/api-v1/post/agents.mdx
@@ -144,9 +144,18 @@ document.addEventListener('DOMContentLoaded', async () => {
 </ParamField>
 
 <ParamField body="tools" type="array">
-  Interact with the real world through API calls.
+  Interact with the real world through API calls, and attach knowledge bases for retrieval during the call. The array accepts both tool IDs and knowledge base UUIDs.
 
-  Detailed tutorial here: [Custom Tools](/tutorials/custom-tools)
+  ```json
+  {
+    "tools": [
+      "TL-ba6c4237-67c2-40e8-868b-60d429a84eda",
+      "389abfee-3a07-4dfb-be71-91c9c3705704"
+    ]
+  }
+  ```
+
+  Knowledge base UUIDs come from [Upload Text](/api-v1/post/knowledge-learn-text), [Upload File](/api-v1/post/knowledge-learn-file), or [Crawl Web](/api-v1/post/knowledge-learn-web). See the [attachment matrix](/api-v1/post/knowledge-learn-text#where-can-a-knowledge-base-be-attached) for the other surfaces that consume the same UUID. Detailed tools tutorial: [Custom Tools](/tutorials/custom-tools).
 </ParamField>
 
 <ParamField body="dynamic_data" type="object">

--- a/api-v1/post/knowledge-learn-file.mdx
+++ b/api-v1/post/knowledge-learn-file.mdx
@@ -6,6 +6,8 @@ description: "Creates a new knowledge base by uploading a file."
 
 Upload a file to create a knowledge base that can be used to provide contextual information to your AI agents. Supported file formats include PDF, Word documents, text files, and more.
 
+This endpoint returns a `data.id` UUID. See [Where can a knowledge base be attached?](/api-v1/post/knowledge-learn-text#where-can-a-knowledge-base-be-attached) for the surfaces that consume the UUID (Web Agents, Personas, Pathway nodes, outbound calls).
+
 ### Headers
 
 <ParamField header="authorization" type="string" required>

--- a/api-v1/post/knowledge-learn-text.mdx
+++ b/api-v1/post/knowledge-learn-text.mdx
@@ -6,6 +6,20 @@ description: "Creates a new knowledge base from direct text input."
 
 Create a knowledge base by providing text content directly in the request. This is ideal for when you have structured text content that you want to make searchable for your AI agents.
 
+This endpoint returns a `data.id` UUID. Plug that UUID into any of the surfaces below to make the knowledge base available on a call. The same UUID can be attached to as many places as you want; the relationship is many-to-many.
+
+### Where can a knowledge base be attached?
+
+| Surface | How to attach | Notes |
+| --- | --- | --- |
+| **Web Agent** (browser SDK) | [`POST /v1/agents`](/api-v1/post/agents) or [`POST /v1/agents/{id}`](/api-v1/post/agents-id), `tools: ["<kb_uuid>"]` | The `tools` array accepts knowledge base UUIDs and tool IDs interchangeably. |
+| **Inbound phone number** | [`POST /v1/personas`](/api-v1/post/personas) or [`PATCH /v1/personas/{id}`](/api-v1/patch/personas-id), `kb_ids: ["<kb_uuid>"]`, then [attach the number](/api-v1/post/personas-id-inbound-attach) | Updates land on the draft; [promote](/api-v1/post/personas-id-versions-promote) before the change is live. |
+| **SMS / iMessage** | Same as inbound phone: set `kb_ids` on the persona, then attach the SMS-capable number | Channel capability follows the number's own configuration. |
+| **Pathway node** | Configure the knowledge base on the node in the pathway builder | See [Pathways](/tutorials/pathways). Nodes hold their own KB list. |
+| **Outbound call** | [`POST /v1/calls`](/api-v1/post/calls), `tools: ["<kb_uuid>"]` | Same array as Web Agents. If `persona_id` is set, the persona's `kb_ids` apply and `tools` adds to them. |
+
+Legacy `KB-` prefixed vector store IDs are no longer issued. Existing `KB-` IDs still resolve, but new knowledge bases use UUIDs.
+
 ### Headers
 
 <ParamField header="authorization" type="string" required>

--- a/api-v1/post/knowledge-learn-web.mdx
+++ b/api-v1/post/knowledge-learn-web.mdx
@@ -6,6 +6,8 @@ description: "Creates a new knowledge base by scraping content from web URLs."
 
 Create a knowledge base by scraping content from one or more web URLs. This is perfect for creating knowledge bases from documentation sites, blog posts, or other web-based content.
 
+This endpoint returns a `data.id` UUID. See [Where can a knowledge base be attached?](/api-v1/post/knowledge-learn-text#where-can-a-knowledge-base-be-attached) for the surfaces that consume the UUID (Web Agents, Personas, Pathway nodes, outbound calls).
+
 ### Headers
 
 <ParamField header="authorization" type="string" required>


### PR DESCRIPTION
## Summary

`POST /v1/knowledge/learn` returns a UUID that can plug into several surfaces, but the docs currently leave developers to figure that out themselves. This PR adds an explicit "Where can a knowledge base be attached?" matrix and cross-links the file and web create endpoints to it. It also expands `tools` on `POST /v1/agents` so it's obvious Web Agents accept KB UUIDs there.

## The matrix (rendered on `knowledge-learn-text.mdx`)

| Surface | How to attach | Notes |
| --- | --- | --- |
| Web Agent (browser SDK) | `POST /v1/agents` or `POST /v1/agents/{id}`, `tools: ["<kb_uuid>"]` | `tools` accepts KB UUIDs and tool IDs interchangeably. |
| Inbound phone number | Persona `kb_ids`, then attach the number to the persona | Updates land on the draft; promote to go live. |
| SMS / iMessage | Persona `kb_ids` with SMS-capable number attached | Channel follows the number's configuration. |
| Pathway node | Configure on the node in the pathway builder | Nodes hold their own KB list. |
| Outbound call | `POST /v1/calls`, `tools: ["<kb_uuid>"]` | If `persona_id` is set, the persona's `kb_ids` also apply. |

## Verified facts (live API, 2026-05-11)

- New KBs are UUIDs (e.g. `389abfee-3a07-4dfb-be71-91c9c3705704`). Legacy `KB-` prefixed IDs are no longer issued but still resolve for backward compatibility.
- `PATCH /v1/agents/{id}` with `tools: ["<kb_uuid>"]` persists and reads back on `GET /v1/agents`.
- The same UUID can be referenced from multiple personas and from `tools` arrays simultaneously.

## Changes

- `api-v1/post/knowledge-learn-text.mdx` — matrix.
- `api-v1/post/knowledge-learn-file.mdx`, `api-v1/post/knowledge-learn-web.mdx` — cross-link to the matrix.
- `api-v1/post/agents.mdx` — expand `tools` field with KB attachment example and matrix link.

## Sibling PRs

This is one of three small replacements for the (now closed) PR #216. The others cover:
- Persona vs Web Agent boundary
- Persona `kb_ids` and version model on `POST/PATCH /v1/personas`

## Test plan

- [ ] Preview renders the new `### Where can a knowledge base be attached?` table with all five rows.
- [ ] The `#where-can-a-knowledge-base-be-attached` anchor referenced from `knowledge-learn-file.mdx`, `knowledge-learn-web.mdx`, and `agents.mdx` resolves.
- [ ] Spot-check that the agents.mdx `tools` example still highlights as JSON.

Generated with Claude Code (https://claude.com/claude-code)
