### PR TITLE
docs: document Persona kb_ids and version model on create/update

### DIFF
--- a/api-v1/patch/personas-id.mdx
+++ b/api-v1/patch/personas-id.mdx
@@ -4,6 +4,10 @@ api: "PATCH https://api.bland.ai/v1/personas/{persona_id}"
 description: "Update an existing persona configuration."
 ---
 
+<Info>
+  **Updates write to the draft, not production.** This endpoint stages changes in `current_draft_version`. Live inbound and SMS calls keep using `current_production_version` until you promote the draft with [Promote Version](/api-v1/post/personas-id-versions-promote).
+</Info>
+
 ### Headers
 
 <ParamField header="authorization" type="string" required>
@@ -63,6 +67,9 @@ description: "Update an existing persona configuration."
     <ParamField body="interruption_threshold" type="number">
       Interruption sensitivity threshold.
     </ParamField>
+    <ParamField body="first_sentence" type="string">
+      Phrase the agent says first instead of generating a greeting on the fly. Must be under 200 characters.
+    </ParamField>
   </Expandable>
 </ParamField>
 
@@ -101,7 +108,9 @@ description: "Update an existing persona configuration."
 </ParamField>
 
 <ParamField body="kb_ids" type="array">
-  Updated array of knowledge base IDs to connect to the persona.
+  Replacement array of knowledge base UUIDs for the persona. Pass the full set you want attached; omitted IDs will be detached on the draft.
+
+  IDs come from [Upload Text](/api-v1/post/knowledge-learn-text), [Upload File](/api-v1/post/knowledge-learn-file), or [Crawl Web](/api-v1/post/knowledge-learn-web). The same knowledge base can be attached to multiple personas. Changes only affect live calls after the draft is promoted.
 </ParamField>
 
 ### Response

--- a/api-v1/post/personas-id-inbound-attach.mdx
+++ b/api-v1/post/personas-id-inbound-attach.mdx
@@ -1,8 +1,12 @@
 ---
 title: "Attach Phone Numbers to Persona"
 api: "POST https://api.bland.ai/v1/personas/{persona_id}/inbound/attach"
-description: "Attach one or more inbound phone numbers to a persona. The same endpoint handles voice, SMS, and WhatsApp numbers — channel capability is determined by the number's own configuration, not by this call."
+description: "Attach one or more inbound phone numbers to a persona. The same endpoint handles voice, SMS, and WhatsApp numbers; channel capability is determined by the number's own configuration, not by this call."
 ---
+
+<Note>
+  Once a number is attached, every inbound call or message it receives uses the persona's `current_production_version`, including any knowledge bases listed in the persona's `kb_ids`. Update the knowledge attachment via [Update Persona](/api-v1/patch/personas-id) and promote the draft to make the change live.
+</Note>
 
 ### Headers
 

--- a/api-v1/post/personas.mdx
+++ b/api-v1/post/personas.mdx
@@ -4,6 +4,12 @@ api: "POST https://api.bland.ai/v1/personas"
 description: "Create a new persona."
 ---
 
+Personas are reusable agent configurations for **inbound phone numbers** and **SMS**. Once created, attach a persona to one or more numbers with [Attach Phone Numbers to Persona](/api-v1/post/personas-id-inbound-attach). For embedded **browser** voice agents, use [Create a Web Agent](/api-v1/post/agents) instead. See [Personas vs. Web Agents](/tutorials/personas#personas-vs-web-agents) for the full comparison.
+
+<Info>
+  **Draft / production split.** Creating a persona writes the initial configuration to both `current_production_version` and `current_draft_version` and auto-promotes it. Any later [Update Persona](/api-v1/patch/personas-id) call writes only to the draft; the draft must be promoted with [Promote Version](/api-v1/post/personas-id-versions-promote) before it affects live calls.
+</Info>
+
 ### Headers
 
 <ParamField header="authorization" type="string" required>
@@ -57,6 +63,9 @@ description: "Create a new persona."
     <ParamField body="interruption_threshold" type="number">
       Interruption sensitivity threshold.
     </ParamField>
+    <ParamField body="first_sentence" type="string">
+      Phrase the agent says first instead of generating a greeting on the fly. Must be under 200 characters.
+    </ParamField>
   </Expandable>
 </ParamField>
 
@@ -95,8 +104,49 @@ description: "Create a new persona."
 </ParamField>
 
 <ParamField body="kb_ids" type="array">
-  Array of knowledge base IDs to connect to the persona.
+  Array of knowledge base UUIDs to attach to the persona. The agent retrieves from these knowledge bases on every call routed through this persona, on both voice and SMS channels.
+
+  IDs come from [Upload Text](/api-v1/post/knowledge-learn-text), [Upload File](/api-v1/post/knowledge-learn-file), or [Crawl Web](/api-v1/post/knowledge-learn-web). Use the `data.id` returned by those endpoints. The relationship is many-to-many: one knowledge base can be referenced from any number of personas.
+
+  Legacy `KB-` prefixed vector store IDs are no longer issued. Existing `KB-` IDs still resolve for backward compatibility, but new knowledge bases use UUIDs.
 </ParamField>
+
+### Request Example
+
+<RequestExample>
+```bash cURL
+curl -X POST https://api.bland.ai/v1/personas \
+  -H "authorization: YOUR_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{
+    "name": "Support persona",
+    "personality_prompt": "You are a helpful support agent for Acme Corp. Be concise and friendly.",
+    "call_config": {
+      "voice": "june",
+      "first_sentence": "Hi, this is Acme support. How can I help?",
+      "interruption_threshold": 100
+    },
+    "kb_ids": [
+      "389abfee-3a07-4dfb-be71-91c9c3705704"
+    ]
+  }'
+```
+
+```json Request Body
+{
+  "name": "Support persona",
+  "personality_prompt": "You are a helpful support agent for Acme Corp. Be concise and friendly.",
+  "call_config": {
+    "voice": "june",
+    "first_sentence": "Hi, this is Acme support. How can I help?",
+    "interruption_threshold": 100
+  },
+  "kb_ids": [
+    "389abfee-3a07-4dfb-be71-91c9c3705704"
+  ]
+}
+```
+</RequestExample>
 
 ### Response
 


### PR DESCRIPTION
## Summary

`POST /v1/personas` already lists `kb_ids` as an accepted field, but the docs don't explain:

- where those IDs come from (the UUID returned by `POST /v1/knowledge/learn`),
- that one knowledge base can be attached to many personas,
- that personas have a draft/production split (the create call auto-promotes, subsequent updates do not),
- that `first_sentence` is accepted under `call_config`.

`PATCH /v1/personas/{id}` has the same gaps and is also silent on the key consequence that updates write to the draft, not production. This PR fills those in.

## Verified facts (live API, 2026-05-11)

- `POST /v1/personas` accepts: `name`, `role`, `description`, `tags`, `image_url`, `call_config` (with `first_sentence`), `orchestration_prompt`, `personality_prompt`, `default_tools`, `pathway_conditions`, `kb_ids`.
- The response includes `current_production_version` and `current_draft_version`. Create auto-promotes the initial config to production; `PATCH` writes to the draft and requires a separate `POST /v1/personas/{id}/versions/promote` to go live.
- `kb_ids` takes UUIDs from `POST /v1/knowledge/learn`. The same UUID can be referenced from any number of personas (many-to-many).
- Numbers attached via `POST /v1/personas/{id}/inbound/attach` answer using the persona's `current_production_version`, including its `kb_ids`.

## Persona create example with `kb_ids` (now in the docs)

```json
POST /v1/personas
{
  "name": "Support persona",
  "personality_prompt": "You are a helpful support agent for Acme Corp.",
  "call_config": {
    "voice": "june",
    "first_sentence": "Hi, this is Acme support. How can I help?",
    "interruption_threshold": 100
  },
  "kb_ids": [
    "389abfee-3a07-4dfb-be71-91c9c3705704"
  ]
}
```

## Changes

- `api-v1/post/personas.mdx` — scoping intro, draft/production callout, `kb_ids` expansion, `first_sentence`, request example.
- `api-v1/patch/personas-id.mdx` — draft/production callout, `kb_ids` expansion, `first_sentence`.
- `api-v1/post/personas-id-inbound-attach.mdx` — note that attached numbers inherit the persona's `kb_ids` and follow its production version.

## Sibling PRs

This is one of three small replacements for the (now closed) PR #216. The others cover:
- Persona vs Web Agent boundary
- KB attachment matrix across surfaces

## Test plan

- [ ] Preview renders the new request example with proper JSON highlighting.
- [ ] Both Info callouts (on create and patch) render correctly.
- [ ] Internal links to `/v1/knowledge/learn`, `/v1/personas/{id}/versions/promote`, and the patch endpoint all resolve.

Generated with Claude Code (https://claude.com/claude-code)
