### PR TITLE
ci: auto-sync changelog/**.mdx into marketing-site Sanity

### DIFF
--- a/.github/workflows/sync-changelog-to-sanity.yml
+++ b/.github/workflows/sync-changelog-to-sanity.yml
@@ -1,0 +1,90 @@
+name: Sync changelog to Sanity
+
+# Mirrors changelog/**.mdx into the marketing site's Sanity CMS whenever a
+# weekly file changes. The marketing-side import script lives in CINTELLILABS/marketing
+# at website/scripts/import-changelog-from-docs.ts and handles MDX parsing, Portable
+# Text conversion, and idempotent create/update against Sanity.
+#
+# Setup (one-time, repo-level secrets):
+#   SANITY_API_TOKEN          editor token on the production dataset
+#   MARKETING_REPO_PAT        fine-grained GitHub PAT with Contents:Read on CINTELLILABS/marketing
+#   SANITY_WEBHOOK_SECRET     same value as the marketing site's env (used to ping /api/revalidate)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'changelog/**'
+  workflow_dispatch: {}
+
+concurrency:
+  group: changelog-sanity-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout docs repo
+        uses: actions/checkout@v4
+        with:
+          path: docs-repo
+
+      - name: Checkout marketing repo (sparse — website/ only)
+        uses: actions/checkout@v4
+        with:
+          repository: CINTELLILABS/marketing
+          token: ${{ secrets.MARKETING_REPO_PAT }}
+          path: marketing
+          sparse-checkout: |
+            website
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: marketing/website/package-lock.json
+
+      - name: Install marketing deps
+        working-directory: marketing/website
+        run: npm ci
+
+      - name: Run import (write + update-existing)
+        working-directory: marketing/website
+        env:
+          SANITY_API_TOKEN: ${{ secrets.SANITY_API_TOKEN }}
+          NEXT_PUBLIC_SANITY_PROJECT_ID: tmmoa80b
+          NEXT_PUBLIC_SANITY_DATASET: production
+        run: |
+          ./node_modules/.bin/tsx scripts/import-changelog-from-docs.ts \
+            --docs-path="$GITHUB_WORKSPACE/docs-repo/changelog" \
+            --update-existing \
+            --write
+
+      - name: Attach screenshots
+        working-directory: marketing/website
+        env:
+          SANITY_API_TOKEN: ${{ secrets.SANITY_API_TOKEN }}
+          NEXT_PUBLIC_SANITY_PROJECT_ID: tmmoa80b
+          NEXT_PUBLIC_SANITY_DATASET: production
+        run: ./node_modules/.bin/tsx scripts/import-changelog-images.ts --apply
+
+      - name: Trigger marketing ISR revalidation
+        env:
+          SANITY_WEBHOOK_SECRET: ${{ secrets.SANITY_WEBHOOK_SECRET }}
+        run: |
+          if [ -z "$SANITY_WEBHOOK_SECRET" ]; then
+            echo "::warning::SANITY_WEBHOOK_SECRET not set; skipping revalidation. New entries will appear within the 1h ISR window."
+            exit 0
+          fi
+          curl -sf -X POST "https://www.bland.ai/api/revalidate" \
+            -H "sanity-webhook-secret: $SANITY_WEBHOOK_SECRET" \
+            -H "content-type: application/json" \
+            -d '{"_type":"changelogEntry"}' \
+            && echo "Revalidation triggered." \
+            || echo "::warning::Revalidation request failed; entries will still appear within the 1h ISR window."


### PR DESCRIPTION
## Summary
Adds a GitHub Action that mirrors weekly `changelog/**.mdx` entries into the marketing site's Sanity CMS. Engineering keeps writing changelog as part of release PRs here in the docs repo — the marketing `/changelog` page stays in lockstep automatically.

## How it works
- **Trigger:** push to `main` with changes under `changelog/**`, or manual via `workflow_dispatch`.
- **What it does:** sparse-checks out `CINTELLILABS/marketing` (website only), runs `scripts/import-changelog-from-docs.ts --update-existing --write` against this repo's `changelog/` directory, attaches screenshots, and pings the marketing site's `/api/revalidate` so the page refreshes within seconds.
- **Idempotent:** safe to re-run. Existing entries get patched only if the source body changed. Removed sections do **not** auto-delete from Sanity (manual operation).
- **Concurrency-safe:** `concurrency: changelog-sanity-sync` blocks overlapping runs.

## Required setup (one-time, repo settings → Secrets and variables → Actions)

| Secret | What | Source |
|--------|------|--------|
| `SANITY_API_TOKEN` | Editor token on the production dataset | 1Password: `Dev - Bland/Sanity API - bland.ai/credential` |
| `MARKETING_REPO_PAT` | Fine-grained GitHub PAT, `Contents: Read` on `CINTELLILABS/marketing`, 90-day rotation | github.com/settings/personal-access-tokens |
| `SANITY_WEBHOOK_SECRET` | Same value as the marketing site's env var; used to hit `/api/revalidate` | 1Password / marketing project env. **Optional** — the workflow falls back to the 1h ISR window if unset. |

## Test plan after merge
- [ ] Open Actions tab, manually trigger via "Run workflow" → expect a no-op (everything from this repo is already in Sanity per PR CINTELLILABS/marketing#165)
- [ ] Open a small docs PR that adds a line to an existing `changelog/MM_DD_YYYY.mdx`, merge it, watch the workflow fire on push and complete in <2min
- [ ] Confirm the edit shows up at https://www.bland.ai/changelog within seconds (revalidate) or within an hour (ISR fallback)

## Companion PR
CINTELLILABS/marketing#165 (already merged) added the import script and Loom embed support that this workflow depends on. Backfill of the 16 missing entries (2026-04-06 through 2026-05-07) is complete; Sanity now holds 119 entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)