### PR TITLE
docs: Live Translation API (TaaS) — tutorial + API reference

### DIFF
--- a/api-v1/delete/translation-sessions-id.mdx
+++ b/api-v1/delete/translation-sessions-id.mdx
@@ -1,0 +1,76 @@
+---
+title: "End Translation Session"
+api: "DELETE https://api.bland.ai/v1/translation/sessions/{session_id}"
+description: "Terminate a translation session from the server side"
+---
+
+Ends a translation session. If the WebSocket is connected, it receives a final `session_ended` control message and is closed. Pending sessions (created but never connected) are also cleaned up — useful for releasing a concurrency slot you no longer need.
+
+Terminating an already-ended session is a no-op and returns the session's final state.
+
+## Authentication
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="session_id" type="string" required>
+  The session UUID returned by `POST /v1/translation/sessions`
+</ParamField>
+
+## Body Parameters
+
+<ParamField body="reason" type="string">
+  Optional context (max 200 characters) recorded with the session's `end_reason` as `api_terminated:<reason>`.
+</ParamField>
+
+## Response
+
+Returns the same session object as [Get Translation Session](/api-v1/get/translation-sessions-id), with `status` and `end_reason` reflecting the termination.
+
+<RequestExample>
+
+```bash cURL
+curl -X DELETE "https://api.bland.ai/v1/translation/sessions/9592342c-0ed2-4c5e-8ceb-16aa55c804a7" \
+  -H "Authorization: YOUR_API_KEY"
+```
+
+```python Python
+import requests
+
+response = requests.delete(
+    "https://api.bland.ai/v1/translation/sessions/9592342c-0ed2-4c5e-8ceb-16aa55c804a7",
+    headers={"Authorization": "YOUR_API_KEY"},
+)
+print(response.json()["data"]["end_reason"])  # "api_terminated"
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json Terminated
+{
+  "data": {
+    "session_id": "9592342c-0ed2-4c5e-8ceb-16aa55c804a7",
+    "status": "ENDED",
+    "source_language": "en",
+    "target_language": "es",
+    "voice_id": null,
+    "audio_protocol": "pcm16",
+    "sample_rate": 16000,
+    "max_duration_seconds": 1800,
+    "end_reason": "api_terminated",
+    "session_seconds": null,
+    "billable_minutes": null,
+    "created_at": "2026-06-04T18:05:07.885Z",
+    "started_at": null,
+    "ended_at": "2026-06-04T18:06:08.684Z"
+  },
+  "errors": null
+}
+```
+
+</ResponseExample>

--- a/api-v1/get/translation-sessions-id.mdx
+++ b/api-v1/get/translation-sessions-id.mdx
@@ -1,0 +1,117 @@
+---
+title: "Get Translation Session"
+api: "GET https://api.bland.ai/v1/translation/sessions/{session_id}"
+description: "Retrieve the status, duration, and billing details of a translation session"
+---
+
+Returns the current state of a translation session — useful for checking whether a session connected, how long it ran, and how many minutes were billed.
+
+## Authentication
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="session_id" type="string" required>
+  The session UUID returned by `POST /v1/translation/sessions`
+</ParamField>
+
+## Response
+
+<ResponseField name="data" type="object">
+  <Expandable title="data properties">
+    <ResponseField name="session_id" type="string">
+      Unique identifier for the session
+    </ResponseField>
+    <ResponseField name="status" type="string">
+      One of `PENDING` (created, WebSocket not yet connected), `ACTIVE` (audio flowing), `ENDED`, `FAILED`, `EXPIRED` (hit max duration), `ABANDONED` (never connected before token expiry)
+    </ResponseField>
+    <ResponseField name="source_language" type="string">
+      Source language code
+    </ResponseField>
+    <ResponseField name="target_language" type="string">
+      Target language code
+    </ResponseField>
+    <ResponseField name="voice_id" type="string">
+      Voice used for translated speech, or `null` for the default
+    </ResponseField>
+    <ResponseField name="audio_protocol" type="string">
+      `pcm16` or `twilio_ulaw`
+    </ResponseField>
+    <ResponseField name="sample_rate" type="integer">
+      Inbound sample rate for `pcm16` sessions; `null` for `twilio_ulaw`
+    </ResponseField>
+    <ResponseField name="max_duration_seconds" type="integer">
+      Configured maximum session length
+    </ResponseField>
+    <ResponseField name="end_reason" type="string">
+      Why the session ended: `client_disconnect`, `max_duration`, `error`, or `api_terminated`. `null` while the session is pending or active.
+    </ResponseField>
+    <ResponseField name="session_seconds" type="number">
+      Connected duration in seconds. `null` until the session ends.
+    </ResponseField>
+    <ResponseField name="billable_minutes" type="integer">
+      Billed minutes (`session_seconds` rounded up to the next minute). `null` until the session ends.
+    </ResponseField>
+    <ResponseField name="created_at" type="string">
+      ISO timestamp of session creation
+    </ResponseField>
+    <ResponseField name="started_at" type="string">
+      ISO timestamp of the WebSocket connection, or `null` if it never connected
+    </ResponseField>
+    <ResponseField name="ended_at" type="string">
+      ISO timestamp of session end, or `null` while pending or active
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="errors" type="array" default="null">
+  Array of error objects if the request failed
+</ResponseField>
+
+<RequestExample>
+
+```bash cURL
+curl "https://api.bland.ai/v1/translation/sessions/9592342c-0ed2-4c5e-8ceb-16aa55c804a7" \
+  -H "Authorization: YOUR_API_KEY"
+```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.bland.ai/v1/translation/sessions/9592342c-0ed2-4c5e-8ceb-16aa55c804a7",
+    headers={"Authorization": "YOUR_API_KEY"},
+)
+print(response.json()["data"]["status"])
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json Ended Session
+{
+  "data": {
+    "session_id": "9592342c-0ed2-4c5e-8ceb-16aa55c804a7",
+    "status": "ENDED",
+    "source_language": "en",
+    "target_language": "es",
+    "voice_id": null,
+    "audio_protocol": "pcm16",
+    "sample_rate": 16000,
+    "max_duration_seconds": 1800,
+    "end_reason": "client_disconnect",
+    "session_seconds": 19.712,
+    "billable_minutes": 1,
+    "created_at": "2026-06-04T18:05:07.885Z",
+    "started_at": "2026-06-04T18:05:08.861Z",
+    "ended_at": "2026-06-04T18:05:28.573Z"
+  },
+  "errors": null
+}
+```
+
+</ResponseExample>

--- a/api-v1/post/translation-sessions.mdx
+++ b/api-v1/post/translation-sessions.mdx
@@ -8,14 +8,10 @@ Creates a translation session and returns a single-use WebSocket URL. Stream aud
 
 See the [Live Translation API tutorial](/tutorials/translation) for the full streaming protocol, audio formats, and integration walkthrough.
 
-<Note>
-  The Translation API is currently available by request. Contact your Bland representative or [support](https://app.bland.ai) to enable it for your organization.
-</Note>
-
 ## Authentication
 
 <ParamField header="authorization" type="string" required>
-  Your API key for authentication
+  Your API key for authentication. The key must belong to an organization — user-scoped keys without an organization are rejected with `403 TAAS_ORG_REQUIRED`.
 </ParamField>
 
 ## Body Parameters
@@ -149,18 +145,6 @@ print(data["ws_url"])  # connect within 10 minutes
 }
 ```
 
-```json Not Enabled
-{
-  "data": null,
-  "errors": [
-    {
-      "error": "FORBIDDEN",
-      "message": "TAAS_NOT_ENABLED"
-    }
-  ]
-}
-```
-
 ```json Concurrency Cap
 {
   "data": null,
@@ -174,3 +158,84 @@ print(data["ws_url"])  # connect within 10 minutes
 ```
 
 </ResponseExample>
+
+## WebSocket Connection
+
+After creating a session, connect to the returned `ws_url` within 10 minutes:
+
+- **URL**: Use `ws_url` exactly as returned — it is opaque and single-use. Do not parse or reconstruct it.
+- **Protocol**: WebSocket (WSS)
+- **Authentication**: Embedded in the URL — no headers required
+- **Frames**: Binary frames carry audio; text frames carry JSON control events
+
+You can start sending audio immediately on connection open — frames are buffered server-side until the pipeline is ready.
+
+### Audio Format: `pcm16`
+
+| Direction | Format |
+|---|---|
+| Client → Bland | Binary frames of raw PCM-16 little-endian mono audio at your declared `sample_rate` |
+| Bland → Client | Binary frames of raw PCM-16 little-endian mono audio at **16,000 Hz** |
+
+No framing or headers — raw samples only. 20ms chunks (640 bytes at 16kHz) are typical.
+
+### Audio Format: `twilio_ulaw`
+
+All frames are JSON text in [Twilio Media Streams](https://www.twilio.com/docs/voice/media-streams) shape — base64 8kHz μ-law audio in `media.payload`. Send a `start` event first so outbound envelopes echo your `streamSid`:
+
+```json
+{ "event": "start", "start": { "streamSid": "MZ..." } }
+{ "event": "media", "media": { "payload": "<base64 μ-law>" } }
+{ "event": "stop" }
+```
+
+Outbound translated audio arrives as `{"event":"media","streamSid":"<your sid>","media":{"payload":"<base64 8kHz μ-law>"}}`.
+
+### Control Events
+
+JSON text frames from the server, discriminated by `type`:
+
+| Event | When | Key fields |
+|---|---|---|
+| `ready` | Pipeline warmed up; transcripts begin flowing after this | `session_id` |
+| `transcript` | One finalized utterance was translated | `turn_id`, `original`, `translation`, `source_language`, `target_language`, `is_final` |
+| `tts_complete` | All translated audio for a turn has been written to the WebSocket | `turn_id`, `audio_duration_ms` |
+| `session_ended` | Terminal notification — last JSON frame before close | `reason`, `session_seconds`, `end_reason` |
+| `error` | Fatal session failure, followed by `session_ended` and close | `code`, `message`, `fatal` |
+
+```json Example transcript event
+{
+  "type": "transcript",
+  "turn_id": "5862a126-2e88-46b1-bb95-0ed5c57155c1",
+  "original": "Hello. This is a translation test.",
+  "translation": "Hola. Esta es una prueba de traducción.",
+  "source_language": "en",
+  "target_language": "es",
+  "is_final": true
+}
+```
+
+<Note>
+  - `audio_duration_ms` is currently always `0` — a placeholder. Do not rely on it.
+  - A `tts_complete` may be absent for a turn whose speech synthesis failed — don't block on it. The transcript still arrives.
+  - Error codes that can fire: `taas/audio_protocol_mismatch` and `taas/internal_error`, both `fatal: true`.
+  - `session_ended.reason` is one of `client_disconnect`, `max_duration`, `error`, `api_terminated`.
+</Note>
+
+### Close Codes
+
+| Code | Meaning |
+|---|---|
+| `1000` | Normal close after `session_ended` |
+| `1011` | Internal server error |
+| `4001` | Invalid, expired, or already-used session token |
+| `4002` | Session not found |
+| `4003` | Session already ended |
+| `4004` | First frame didn't match the declared `audio_protocol` |
+| `4005` | `max_duration_seconds` reached |
+
+## Notes
+
+- Translated audio can arrive faster than real time — buffer client-side and play at the natural rate
+- Reconnection is not supported; if the WebSocket drops, create a new session
+- The WebSocket closes automatically at `max_duration_seconds`

--- a/api-v1/post/translation-sessions.mdx
+++ b/api-v1/post/translation-sessions.mdx
@@ -1,0 +1,176 @@
+---
+title: "Create Translation Session"
+api: "POST https://api.bland.ai/v1/translation/sessions"
+description: "Create a real-time translation session and receive a WebSocket URL for streaming audio"
+---
+
+Creates a translation session and returns a single-use WebSocket URL. Stream audio in your source language and receive translated speech back in real time — along with transcript events for every translated utterance.
+
+See the [Live Translation API tutorial](/tutorials/translation) for the full streaming protocol, audio formats, and integration walkthrough.
+
+<Note>
+  The Translation API is currently available by request. Contact your Bland representative or [support](https://app.bland.ai) to enable it for your organization.
+</Note>
+
+## Authentication
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Body Parameters
+
+<ParamField body="source_language" type="string" required>
+  Language the inbound audio is spoken in. Supported codes: `en`, `es`, `fr`, `de`, `it`, `pt`, `nl`, `pl`, `sv`, `fi`, `da`, `cs`, `el`, `ro`, `ru`, `tr`, `ar`, `hi`, `id`, `tl`, `zh`, `ja`, `ko`
+</ParamField>
+
+<ParamField body="target_language" type="string" required>
+  Language to translate into. Same supported codes as `source_language`.
+</ParamField>
+
+<ParamField body="voice_id" type="string">
+  UUID of a Bland voice to use for the translated speech. Must belong to your organization. Defaults to a standard voice for the target language.
+</ParamField>
+
+<ParamField body="audio_protocol" type="string" default="pcm16">
+  Wire format for audio on the WebSocket. One of:
+  - `pcm16` — raw PCM-16 little-endian binary frames
+  - `twilio_ulaw` — Twilio Media Streams JSON envelopes carrying 8kHz μ-law audio, for direct interop with Twilio `<Stream>`
+</ParamField>
+
+<ParamField body="sample_rate" type="integer" default="16000">
+  Sample rate of the audio you will send, in Hz. `pcm16` mode only — integer between `8000` and `48000`. `16000` is recommended. Do not set this for `twilio_ulaw` (Twilio audio is always 8kHz).
+</ParamField>
+
+<ParamField body="max_duration_seconds" type="integer" default="1800">
+  Maximum session length in seconds, between `30` and `1800`. The session ends automatically when this limit is reached.
+</ParamField>
+
+## Response
+
+<ResponseField name="data" type="object">
+  <Expandable title="data properties">
+    <ResponseField name="session_id" type="string">
+      Unique identifier for the session. Use it with the GET and DELETE endpoints.
+    </ResponseField>
+    <ResponseField name="ws_url" type="string">
+      WebSocket URL to connect to. **Treat this as opaque** — connect to it exactly as returned. Do not parse or reconstruct it.
+    </ResponseField>
+    <ResponseField name="token" type="string">
+      Session token. Already embedded in `ws_url`; returned separately for reference.
+    </ResponseField>
+    <ResponseField name="expires_at" type="string">
+      ISO timestamp. Connect to `ws_url` before this time (10 minutes after creation) or the session is abandoned.
+    </ResponseField>
+    <ResponseField name="max_duration_seconds" type="integer">
+      The resolved maximum session length.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="errors" type="array" default="null">
+  Array of error objects if the request failed
+</ResponseField>
+
+<Warning>
+  The `ws_url` is **single-use**: it authenticates exactly one WebSocket connection. If your connection drops, create a new session — reconnecting with the same URL is rejected with close code `4001`.
+</Warning>
+
+## Limits & Billing
+
+- Sessions are billed **per minute** of connected time, rounded up. The per-minute rate depends on your plan.
+- Up to **3 concurrent sessions** per organization (pending sessions count until they expire). Contact us to raise this limit.
+- A daily translation-minutes rate limit applies per organization.
+
+<RequestExample>
+
+```bash cURL
+curl -X POST "https://api.bland.ai/v1/translation/sessions" \
+  -H "Authorization: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source_language": "en",
+    "target_language": "es",
+    "audio_protocol": "pcm16",
+    "sample_rate": 16000
+  }'
+```
+
+```javascript JavaScript
+const response = await fetch("https://api.bland.ai/v1/translation/sessions", {
+  method: "POST",
+  headers: {
+    "Authorization": "YOUR_API_KEY",
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    source_language: "en",
+    target_language: "es",
+    audio_protocol: "pcm16",
+    sample_rate: 16000,
+  }),
+});
+
+const { data } = await response.json();
+const ws = new WebSocket(data.ws_url); // connect within 10 minutes
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://api.bland.ai/v1/translation/sessions",
+    headers={"Authorization": "YOUR_API_KEY"},
+    json={
+        "source_language": "en",
+        "target_language": "es",
+        "audio_protocol": "pcm16",
+        "sample_rate": 16000,
+    },
+)
+data = response.json()["data"]
+print(data["ws_url"])  # connect within 10 minutes
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json Success
+{
+  "data": {
+    "session_id": "9592342c-0ed2-4c5e-8ceb-16aa55c804a7",
+    "ws_url": "wss://stream-v2.aws.dc8.bland.ai/ws/translate/eyJhbGciOiJBMjU2R0NNS1ciLCJlbmMiOiJBMjU2R0NN...",
+    "token": "fe120676-1b18-4c87-b6fc-c984e719d3bc",
+    "expires_at": "2026-06-04T18:15:07.885Z",
+    "max_duration_seconds": 1800
+  },
+  "errors": null
+}
+```
+
+```json Not Enabled
+{
+  "data": null,
+  "errors": [
+    {
+      "error": "FORBIDDEN",
+      "message": "TAAS_NOT_ENABLED"
+    }
+  ]
+}
+```
+
+```json Concurrency Cap
+{
+  "data": null,
+  "errors": [
+    {
+      "error": "TOO_MANY_REQUESTS",
+      "message": "CONCURRENCY_CAP_EXCEEDED"
+    }
+  ]
+}
+```
+
+</ResponseExample>

--- a/docs.json
+++ b/docs.json
@@ -61,6 +61,7 @@
                   "tutorials/post-call-webhooks",
                   "tutorials/webhook-signing",
                   "tutorials/personas",
+                  "tutorials/translation",
                   "tutorials/chat-widget",
                   "tutorials/outcomes",
                   "tutorials/alerts",
@@ -477,6 +478,14 @@
                   "api-v1/post/agents-id-authorize",
                   "api-v1/post/agents-id-delete",
                   "api-v1/get/agents"
+                ]
+              },
+              {
+                "group": "Live Translation",
+                "pages": [
+                  "api-v1/post/translation-sessions",
+                  "api-v1/get/translation-sessions-id",
+                  "api-v1/delete/translation-sessions-id"
                 ]
               },
               {

--- a/tutorials/translation.mdx
+++ b/tutorials/translation.mdx
@@ -1,0 +1,257 @@
+---
+title: "Live Translation API"
+description: "Stream audio in one language, get translated speech back in real time."
+---
+
+## Introduction
+
+The Live Translation API gives you Bland's real-time speech translation engine as a standalone service. Open a WebSocket, stream audio in the source language, and receive translated speech back — along with transcript events for every utterance.
+
+<CardGroup cols={2}>
+  <Card title="Real-Time Streaming" icon="bolt">
+    Speech-to-speech translation over a single WebSocket. Transcripts and translated audio arrive per utterance as the speaker talks.
+  </Card>
+  <Card title="Two Audio Protocols" icon="waveform-lines">
+    Raw PCM-16 for web and custom integrations, or Twilio Media Streams envelopes for drop-in interop with Twilio `<Stream>`.
+  </Card>
+  <Card title="23 Languages" icon="globe">
+    Translate between any pair of supported languages, with configurable Bland voices for the translated speech.
+  </Card>
+  <Card title="Session-Based Billing" icon="clock">
+    Billed per minute of connected session time. Track duration and billed minutes through the session API.
+  </Card>
+</CardGroup>
+
+<Note>
+  The Translation API is currently available by request. Contact your Bland representative to enable it for your organization. Attempting to create a session without access returns `403 TAAS_NOT_ENABLED`.
+</Note>
+
+---
+
+## How It Works
+
+```
+POST /v1/translation/sessions          ① create a session
+        │  returns ws_url (single-use, valid 10 min)
+        ▼
+wss://… (connect to ws_url)            ② open the WebSocket
+        │
+        │  ──► you stream source-language audio
+        │  ◄── { "type": "ready" }
+        │  ◄── translated audio frames
+        │  ◄── { "type": "transcript", … }   per utterance
+        │  ◄── { "type": "tts_complete", … } per utterance
+        ▼
+close (either side)                     ③ session ends
+        │  ◄── { "type": "session_ended", … }
+        ▼
+GET /v1/translation/sessions/:id       ④ read final state + billed minutes
+```
+
+1. **Create a session** with [`POST /v1/translation/sessions`](/api-v1/post/translation-sessions). You choose the language pair, audio protocol, and optionally a voice.
+2. **Connect to `ws_url`** exactly as returned — it's an opaque, single-use URL valid for 10 minutes. Do not parse or modify it.
+3. **Stream audio and consume events.** Binary frames are audio; text frames are JSON control events.
+4. **Close the WebSocket** when done (or call [`DELETE`](/api-v1/delete/translation-sessions-id), or let `max_duration_seconds` end it).
+
+<Warning>
+  `ws_url` authenticates **exactly one** connection. If the WebSocket drops, the session is over — create a new session to continue. Reconnect attempts with a used URL are rejected with close code `4001`.
+</Warning>
+
+---
+
+## Audio Protocols
+
+Declare the protocol at session creation with `audio_protocol`. The server also verifies it against the first frame you send — a mismatch closes the connection with code `4004`.
+
+### `pcm16` (default)
+
+Best for web apps, native clients, and server-side integrations.
+
+| Direction | Format |
+|---|---|
+| **You → Bland** | Binary WebSocket frames of raw PCM-16 little-endian mono audio at your declared `sample_rate` (8000–48000 Hz; 16000 recommended) |
+| **Bland → You** | Binary WebSocket frames of raw PCM-16 little-endian mono audio at **16000 Hz** |
+
+No framing or headers — just raw samples. Chunk size is up to you; 20ms chunks (640 bytes at 16kHz) are typical.
+
+### `twilio_ulaw`
+
+Best for piping a Twilio call into translation. The wire format matches [Twilio Media Streams](https://www.twilio.com/docs/voice/media-streams) exactly, so you can forward Twilio's WebSocket messages with minimal glue.
+
+| Direction | Format |
+|---|---|
+| **You → Bland** | JSON text frames in Twilio Media Streams shape (see below). Audio is base64 8kHz μ-law in `media.payload`. |
+| **Bland → You** | JSON text frames: `{"event":"media","streamSid":"<your sid>","media":{"payload":"<base64 8kHz μ-law>"}}` |
+
+Send a `start` event first so outbound envelopes echo your `streamSid`:
+
+```json
+{ "event": "start", "start": { "streamSid": "MZ..." } }
+{ "event": "media", "media": { "payload": "<base64 μ-law>" } }
+{ "event": "stop" }
+```
+
+Do **not** set `sample_rate` for `twilio_ulaw` sessions — Twilio audio is always 8kHz.
+
+---
+
+## Control Events
+
+JSON text frames from the server. Every event has a `type` discriminator.
+
+### `ready`
+
+The pipeline is warmed up. Audio sent before `ready` is buffered, so you can start streaming immediately on connection open — but transcripts won't flow until after `ready`.
+
+```json
+{ "type": "ready", "session_id": "9592342c-…" }
+```
+
+### `transcript`
+
+One finalized utterance with its translation.
+
+```json
+{
+  "type": "transcript",
+  "turn_id": "5862a126-2e88-46b1-bb95-0ed5c57155c1",
+  "original": "Hello. This is a translation test.",
+  "translation": "Hola. Esta es una prueba de traducción.",
+  "source_language": "en",
+  "target_language": "es",
+  "is_final": true
+}
+```
+
+### `tts_complete`
+
+All translated audio for a turn has been written to the WebSocket.
+
+```json
+{ "type": "tts_complete", "turn_id": "5862a126-…", "audio_duration_ms": 6440 }
+```
+
+<Tip>
+  Translated audio can arrive **faster than real time** — a 13-second utterance may be delivered in 7 seconds of wall-clock time. Buffer it client-side and play at the natural rate; use `tts_complete` to know when a turn's audio is fully delivered.
+</Tip>
+
+### `session_ended`
+
+The last JSON frame before the server closes the WebSocket.
+
+```json
+{
+  "type": "session_ended",
+  "reason": "max_duration",
+  "session_seconds": 1800,
+  "end_reason": "max_duration"
+}
+```
+
+`reason` is one of `client_disconnect`, `max_duration`, `error`, `api_terminated`.
+
+### `error`
+
+```json
+{ "type": "error", "code": "taas/tts_failed", "message": "…", "fatal": false }
+```
+
+Non-fatal errors (`fatal: false`) mean the session continues — e.g. a single turn's TTS failed. Fatal errors are followed by `session_ended` and a close.
+
+---
+
+## Close Codes
+
+| Code | Meaning |
+|---|---|
+| `1000` | Normal close after `session_ended` |
+| `1011` | Internal server error |
+| `4001` | Invalid, expired, or already-used session token |
+| `4002` | Session not found |
+| `4003` | Session already ended |
+| `4004` | Audio protocol mismatch (first frame didn't match the declared `audio_protocol`) |
+| `4005` | `max_duration_seconds` reached |
+
+---
+
+## Quickstart (Node.js, pcm16)
+
+```javascript
+const WebSocket = require("ws");
+
+// 1. Create a session
+const resp = await fetch("https://api.bland.ai/v1/translation/sessions", {
+  method: "POST",
+  headers: {
+    Authorization: "YOUR_API_KEY",
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    source_language: "en",
+    target_language: "es",
+    audio_protocol: "pcm16",
+    sample_rate: 16000,
+  }),
+});
+const { data } = await resp.json();
+
+// 2. Connect — ws_url is opaque and single-use
+const ws = new WebSocket(data.ws_url);
+
+ws.on("open", () => {
+  // Safe to start streaming immediately; frames are buffered until ready.
+  streamMicrophoneAudio(ws); // your code: send raw PCM-16 LE 16k binary frames
+});
+
+ws.on("message", (frame, isBinary) => {
+  if (isBinary) {
+    playTranslatedAudio(frame); // raw PCM-16 LE 16k — buffer and play
+    return;
+  }
+  const event = JSON.parse(frame.toString());
+  switch (event.type) {
+    case "ready":
+      console.log("pipeline ready");
+      break;
+    case "transcript":
+      console.log(`${event.original} → ${event.translation}`);
+      break;
+    case "session_ended":
+      console.log(`ended: ${event.reason} (${event.session_seconds}s)`);
+      break;
+    case "error":
+      if (event.fatal) console.error("fatal:", event.code);
+      break;
+  }
+});
+```
+
+---
+
+## Limits
+
+| Limit | Value |
+|---|---|
+| Concurrent sessions per organization | 3 (contact us to raise) |
+| Session length | 30s minimum, 30 minutes maximum |
+| Connection window after create | 10 minutes |
+| Daily translation minutes | Per-organization rate limit |
+| Reconnection | Not supported — create a new session |
+
+## Billing
+
+Sessions are billed per minute of connected time, rounded up to the next whole minute (a 19-second session bills as 1 minute). The per-minute rate depends on your plan. Read `billable_minutes` from [`GET /v1/translation/sessions/:id`](/api-v1/get/translation-sessions-id) after a session ends.
+
+## API Reference
+
+<CardGroup cols={3}>
+  <Card title="Create Session" icon="plus" href="/api-v1/post/translation-sessions">
+    `POST /v1/translation/sessions`
+  </Card>
+  <Card title="Get Session" icon="magnifying-glass" href="/api-v1/get/translation-sessions-id">
+    `GET /v1/translation/sessions/:id`
+  </Card>
+  <Card title="End Session" icon="stop" href="/api-v1/delete/translation-sessions-id">
+    `DELETE /v1/translation/sessions/:id`
+  </Card>
+</CardGroup>

--- a/tutorials/translation.mdx
+++ b/tutorials/translation.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Live Translation API"
-description: "Stream audio in one language, get translated speech back in real time."
+description: "Stream audio and receive translated audio back in real time."
 ---
 
 ## Introduction
 
-The Live Translation API gives you Bland's real-time speech translation engine as a standalone service. Open a WebSocket, stream audio in the source language, and receive translated speech back — along with transcript events for every utterance.
+The Live Translation API gives you Bland's real-time speech translation engine as a standalone service. Open a WebSocket, stream audio in the source language, and receive translated speech back.
 
 <CardGroup cols={2}>
   <Card title="Real-Time Streaming" icon="bolt">
@@ -22,159 +22,28 @@ The Live Translation API gives you Bland's real-time speech translation engine a
   </Card>
 </CardGroup>
 
-<Note>
-  The Translation API is currently available by request. Contact your Bland representative to enable it for your organization. Attempting to create a session without access returns `403 TAAS_NOT_ENABLED`.
-</Note>
+## How it works
 
----
+1. **Create a session** with [`POST /v1/translation/sessions`](/api-v1/post/translation-sessions), choosing the language pair, audio protocol, and optionally a voice.
+2. **Connect to the returned `ws_url`** within 10 minutes. The URL is opaque and single-use — connect to it exactly as returned.
+3. **Stream audio and consume events.** Binary frames are audio; text frames are JSON control events (`ready`, `transcript`, `tts_complete`, `session_ended`, `error`).
+4. **Close the WebSocket** when done — or end the session from your backend with [`DELETE`](/api-v1/delete/translation-sessions-id), or let the session's max duration end it.
 
-## How It Works
+After the session ends, [`GET /v1/translation/sessions/:id`](/api-v1/get/translation-sessions-id) returns the final state, duration, and billed minutes.
 
-```
-POST /v1/translation/sessions          ① create a session
-        │  returns ws_url (single-use, valid 10 min)
-        ▼
-wss://… (connect to ws_url)            ② open the WebSocket
-        │
-        │  ──► you stream source-language audio
-        │  ◄── { "type": "ready" }
-        │  ◄── translated audio frames
-        │  ◄── { "type": "transcript", … }   per utterance
-        │  ◄── { "type": "tts_complete", … } per utterance
-        ▼
-close (either side)                     ③ session ends
-        │  ◄── { "type": "session_ended", … }
-        ▼
-GET /v1/translation/sessions/:id       ④ read final state + billed minutes
-```
+## Choosing an audio protocol
 
-1. **Create a session** with [`POST /v1/translation/sessions`](/api-v1/post/translation-sessions). You choose the language pair, audio protocol, and optionally a voice.
-2. **Connect to `ws_url`** exactly as returned — it's an opaque, single-use URL valid for 10 minutes. Do not parse or modify it.
-3. **Stream audio and consume events.** Binary frames are audio; text frames are JSON control events.
-4. **Close the WebSocket** when done (or call [`DELETE`](/api-v1/delete/translation-sessions-id), or let `max_duration_seconds` end it).
+| | `pcm16` (default) | `twilio_ulaw` |
+|---|---|---|
+| **Best for** | Web apps, native clients, server-side audio | Piping a Twilio call into translation |
+| **Wire format** | Raw PCM-16 binary frames | Twilio Media Streams JSON envelopes |
+| **Sample rate** | You choose (8–48kHz in, 16kHz out) | Always 8kHz μ-law |
 
-<Warning>
-  `ws_url` authenticates **exactly one** connection. If the WebSocket drops, the session is over — create a new session to continue. Reconnect attempts with a used URL are rejected with close code `4001`.
-</Warning>
+With `twilio_ulaw`, the wire format matches Twilio's `<Stream>` messages exactly, so you can forward Twilio's WebSocket frames with minimal glue code.
 
----
+Full wire formats, control-event schemas, and close codes are in the [API reference](/api-v1/post/translation-sessions#websocket-connection).
 
-## Audio Protocols
-
-Declare the protocol at session creation with `audio_protocol`. The server also verifies it against the first frame you send — a mismatch closes the connection with code `4004`.
-
-### `pcm16` (default)
-
-Best for web apps, native clients, and server-side integrations.
-
-| Direction | Format |
-|---|---|
-| **You → Bland** | Binary WebSocket frames of raw PCM-16 little-endian mono audio at your declared `sample_rate` (8000–48000 Hz; 16000 recommended) |
-| **Bland → You** | Binary WebSocket frames of raw PCM-16 little-endian mono audio at **16000 Hz** |
-
-No framing or headers — just raw samples. Chunk size is up to you; 20ms chunks (640 bytes at 16kHz) are typical.
-
-### `twilio_ulaw`
-
-Best for piping a Twilio call into translation. The wire format matches [Twilio Media Streams](https://www.twilio.com/docs/voice/media-streams) exactly, so you can forward Twilio's WebSocket messages with minimal glue.
-
-| Direction | Format |
-|---|---|
-| **You → Bland** | JSON text frames in Twilio Media Streams shape (see below). Audio is base64 8kHz μ-law in `media.payload`. |
-| **Bland → You** | JSON text frames: `{"event":"media","streamSid":"<your sid>","media":{"payload":"<base64 8kHz μ-law>"}}` |
-
-Send a `start` event first so outbound envelopes echo your `streamSid`:
-
-```json
-{ "event": "start", "start": { "streamSid": "MZ..." } }
-{ "event": "media", "media": { "payload": "<base64 μ-law>" } }
-{ "event": "stop" }
-```
-
-Do **not** set `sample_rate` for `twilio_ulaw` sessions — Twilio audio is always 8kHz.
-
----
-
-## Control Events
-
-JSON text frames from the server. Every event has a `type` discriminator.
-
-### `ready`
-
-The pipeline is warmed up. Audio sent before `ready` is buffered, so you can start streaming immediately on connection open — but transcripts won't flow until after `ready`.
-
-```json
-{ "type": "ready", "session_id": "9592342c-…" }
-```
-
-### `transcript`
-
-One finalized utterance with its translation.
-
-```json
-{
-  "type": "transcript",
-  "turn_id": "5862a126-2e88-46b1-bb95-0ed5c57155c1",
-  "original": "Hello. This is a translation test.",
-  "translation": "Hola. Esta es una prueba de traducción.",
-  "source_language": "en",
-  "target_language": "es",
-  "is_final": true
-}
-```
-
-### `tts_complete`
-
-All translated audio for a turn has been written to the WebSocket.
-
-```json
-{ "type": "tts_complete", "turn_id": "5862a126-…", "audio_duration_ms": 6440 }
-```
-
-<Tip>
-  Translated audio can arrive **faster than real time** — a 13-second utterance may be delivered in 7 seconds of wall-clock time. Buffer it client-side and play at the natural rate; use `tts_complete` to know when a turn's audio is fully delivered.
-</Tip>
-
-### `session_ended`
-
-The last JSON frame before the server closes the WebSocket.
-
-```json
-{
-  "type": "session_ended",
-  "reason": "max_duration",
-  "session_seconds": 1800,
-  "end_reason": "max_duration"
-}
-```
-
-`reason` is one of `client_disconnect`, `max_duration`, `error`, `api_terminated`.
-
-### `error`
-
-```json
-{ "type": "error", "code": "taas/tts_failed", "message": "…", "fatal": false }
-```
-
-Non-fatal errors (`fatal: false`) mean the session continues — e.g. a single turn's TTS failed. Fatal errors are followed by `session_ended` and a close.
-
----
-
-## Close Codes
-
-| Code | Meaning |
-|---|---|
-| `1000` | Normal close after `session_ended` |
-| `1011` | Internal server error |
-| `4001` | Invalid, expired, or already-used session token |
-| `4002` | Session not found |
-| `4003` | Session already ended |
-| `4004` | Audio protocol mismatch (first frame didn't match the declared `audio_protocol`) |
-| `4005` | `max_duration_seconds` reached |
-
----
-
-## Quickstart (Node.js, pcm16)
+## Quickstart
 
 ```javascript
 const WebSocket = require("ws");
@@ -199,7 +68,7 @@ const { data } = await resp.json();
 const ws = new WebSocket(data.ws_url);
 
 ws.on("open", () => {
-  // Safe to start streaming immediately; frames are buffered until ready.
+  // Safe to start streaming immediately; frames buffer until ready.
   streamMicrophoneAudio(ws); // your code: send raw PCM-16 LE 16k binary frames
 });
 
@@ -209,38 +78,23 @@ ws.on("message", (frame, isBinary) => {
     return;
   }
   const event = JSON.parse(frame.toString());
-  switch (event.type) {
-    case "ready":
-      console.log("pipeline ready");
-      break;
-    case "transcript":
-      console.log(`${event.original} → ${event.translation}`);
-      break;
-    case "session_ended":
-      console.log(`ended: ${event.reason} (${event.session_seconds}s)`);
-      break;
-    case "error":
-      if (event.fatal) console.error("fatal:", event.code);
-      break;
+  if (event.type === "transcript") {
+    console.log(`${event.original} → ${event.translation}`);
   }
 });
 ```
 
----
+## Best practices
 
-## Limits
+- **Buffer translated audio client-side.** It can arrive faster than real time — a 13-second utterance may be delivered in 7 seconds. Play at the natural rate and use `tts_complete` to know when a turn's audio is fully delivered.
+- **Treat `ws_url` as a secret and as opaque.** It embeds the session's auth. Don't log it, parse it, or reuse it — it authenticates exactly one connection.
+- **Don't block on `tts_complete`.** If a turn's speech synthesis fails, the transcript still arrives but its `tts_complete` may not.
+- **Handle disconnects by creating a new session.** Reconnection isn't supported; a dropped WebSocket ends the session.
+- **Release sessions you don't use.** Pending sessions count toward your concurrency cap until they expire — `DELETE` them if you create one and don't connect.
 
-| Limit | Value |
-|---|---|
-| Concurrent sessions per organization | 3 (contact us to raise) |
-| Session length | 30s minimum, 30 minutes maximum |
-| Connection window after create | 10 minutes |
-| Daily translation minutes | Per-organization rate limit |
-| Reconnection | Not supported — create a new session |
+## Limits and billing
 
-## Billing
-
-Sessions are billed per minute of connected time, rounded up to the next whole minute (a 19-second session bills as 1 minute). The per-minute rate depends on your plan. Read `billable_minutes` from [`GET /v1/translation/sessions/:id`](/api-v1/get/translation-sessions-id) after a session ends.
+Sessions are billed per minute of connected time, rounded up — a 19-second session bills as 1 minute. The per-minute rate depends on your plan. Each organization can run up to 3 concurrent sessions (contact us to raise this) and sessions cap at 30 minutes.
 
 ## API Reference
 

--- a/tutorials/translation.mdx
+++ b/tutorials/translation.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Live Translation API"
+title: "Live Translation"
 description: "Stream audio and receive translated audio back in real time."
 ---
 

--- a/tutorials/translation.mdx
+++ b/tutorials/translation.mdx
@@ -88,7 +88,6 @@ ws.on("message", (frame, isBinary) => {
 
 - **Buffer translated audio client-side.** It can arrive faster than real time — a 13-second utterance may be delivered in 7 seconds. Play at the natural rate and use `tts_complete` to know when a turn's audio is fully delivered.
 - **Treat `ws_url` as a secret and as opaque.** It embeds the session's auth. Don't log it, parse it, or reuse it — it authenticates exactly one connection.
-- **Don't block on `tts_complete`.** If a turn's speech synthesis fails, the transcript still arrives but its `tts_complete` may not.
 - **Handle disconnects by creating a new session.** Reconnection isn't supported; a dropped WebSocket ends the session.
 - **Release sessions you don't use.** Pending sessions count toward your concurrency cap until they expire — `DELETE` them if you create one and don't connect.
 


### PR DESCRIPTION
Public docs for the Live Translation API (TaaS), shipped in `CINTELLILABS/SERVER` #9097 + #9188 and verified end-to-end against prod.

## New pages

- `tutorials/translation.mdx` — narrative guide following the house tutorial scaffold (Introduction / How it works / Choosing an audio protocol / Quickstart / Best practices / Limits and billing / API Reference)
- `api-v1/post/translation-sessions.mdx` — create endpoint + full WebSocket protocol spec inline (audio wire formats for `pcm16` and `twilio_ulaw`, control events, close codes), following the `calls-id-listen.mdx` precedent
- `api-v1/get/translation-sessions-id.mdx` — session readback (status, duration, `billable_minutes`)
- `api-v1/delete/translation-sessions-id.mdx` — server-side termination
- `docs.json` — nav: tutorial under **Advanced Features**, new **Live Translation** group in API Reference

## Accuracy notes (verified against shipped code, not the design doc)

- `audio_duration_ms` documented as a `0` placeholder (coordinator hardcodes it in v1)
- Only the two error codes that actually fire are documented (`taas/audio_protocol_mismatch`, `taas/internal_error` — both fatal)
- `tts_complete` documented as not guaranteed per turn (TTS-failure path skips it)
- Response examples use real shapes captured from prod smoke runs (tokens redacted)

## ⚠️ Merge order

Do **not** merge until `CINTELLILABS/SERVER` #9201 (entitlement-gate removal) **deploys to prod**. These docs describe self-serve access; until #9201 is live, un-entitled orgs still get `403 TAAS_NOT_ENABLED`.