### PR TITLE
Document resumption_speed and interruptibility (call-level and node-level)

### DIFF
--- a/api-v1/post/calls.mdx
+++ b/api-v1/post/calls.mdx
@@ -231,6 +231,25 @@ Send an AI phone call with a custom objective and actions. This endpoint can be 
   Lower values mean the AI will respond more quickly, while higher values mean the AI will wait longer before responding.
 </ParamField>
 
+<ParamField body="resumption_speed" default="2" type="integer">
+  Controls how quickly the AI starts speaking again after the caller finishes a turn. A lower value responds sooner; a higher value waits longer, leaving more room for the caller to continue.
+
+  - `1`: Fast. Responds sooner after the caller pauses.
+  - `2`: Medium (default).
+  - `3`: Slow. Waits longer before responding.
+
+  Supersedes `interruption_threshold`. When both are sent, `resumption_speed` takes precedence.
+</ParamField>
+
+<ParamField body="interruptibility" default="2" type="integer">
+  Controls how readily the AI stops speaking when the caller talks over it. A higher value yields more easily; a lower value holds the turn through more of the caller's speech.
+
+  - `0`: Block. The AI ignores interruptions and finishes speaking (same as `block_interruptions: true`).
+  - `1`: Difficult. Harder to interrupt.
+  - `2`: Balanced (default).
+  - `3`: Easy. The AI stops quickly when the caller begins speaking.
+</ParamField>
+
 ### Dispatch Parameters
 
 <ParamField body="from" type="string">

--- a/api-v1/post/update_pathways.mdx
+++ b/api-v1/post/update_pathways.mdx
@@ -212,6 +212,10 @@ description: "Update a conversational pathway's fields - including name, descrip
           — The name of the model to be used for this node.
         - `interruptionThreshold`
             — The sensitivity to interruptions at this node
+        - `resumption_speed`
+          — How quickly the AI starts speaking again after the caller finishes a turn while on this node: `1` fast, `2` medium (default), `3` slow. Supersedes `interruptionThreshold` when both are set. Useful per node: e.g. slow on a data-collection node so the caller can finish their digits.
+        - `interruptibility`
+          — How readily the AI stops speaking when the caller talks over it on this node: `0` block (the AI finishes speaking, same as `block_interruptions: true`), `1` difficult, `2` balanced (default), `3` easy. Useful per node: e.g. difficult on a legal-disclaimer node.
         - `temperature`
           — The temperature of the model.
       - `extractVars`


### PR DESCRIPTION
Documents the two turn-taking params shipped with the interruptibility/resumption work:

- `POST /v1/calls`: `resumption_speed` (1 fast / 2 medium default / 3 slow; supersedes `interruption_threshold`) and `interruptibility` (0 block / 1 difficult / 2 balanced default / 3 easy).
- `POST /v1/pathway/{id}` (update pathway): the same two params on a node's `modelOptions`, applied on node transition, so a pathway can vary them per node (e.g. difficult interruptibility on a legal-disclaimer node, slow resumption while collecting digits).

The node-level section answers a question raised in Slack about whether these settings extend to nodes; they do, and were undocumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)