### PR TITLE
Document the post-transfer transcript stream

### DIFF
--- a/api-v1/post/calls-id-transcript-stream-token.mdx
+++ b/api-v1/post/calls-id-transcript-stream-token.mdx
@@ -1,0 +1,76 @@
+---
+title: "Mint Transcript Stream Token"
+api: "POST https://api.bland.ai/v1/calls/{call_id}/transcript-stream/token"
+description: "Mint a short-lived JWT for connecting to a call's live post-transfer transcript stream."
+---
+
+## Overview
+
+Mints a short-lived JWT scoped to one call that can be passed as the `token` query parameter when opening the [Post-Transfer Transcript Stream (WebSocket)](/api-v1/post/calls-id-transcript-stream). Use this from your backend so browser clients never see your long-lived API key.
+
+Tokens are valid for 5 minutes and only authorize a stream for the call they were minted for. The call must belong to your organization.
+
+<Note>
+  The post-transfer transcript stream is in limited rollout. If this endpoint returns 403 with `FEATURE_NOT_ENABLED`, it is not yet enabled for your organization.
+</Note>
+
+---
+
+## Headers
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication.
+</ParamField>
+
+---
+
+## Path Parameters
+
+<ParamField path="call_id" type="string" required>
+  The call whose post-transfer transcript you want to stream. The call must have been created with `include_post_transfer_transcript: true`.
+</ParamField>
+
+---
+
+## Body Parameters
+
+This endpoint takes no body. POST an empty body or `{}`.
+
+---
+
+## Response
+
+<ResponseField name="data.token" type="string">
+  JWT to pass as `?token=<token>` on the WebSocket URL.
+</ResponseField>
+
+<ResponseField name="data.expires_in_seconds" type="number">
+  Lifetime of the token. Currently `300` (5 minutes). The TTL gates the connection handshake only; an established stream is not closed when the token expires.
+</ResponseField>
+
+<ResponseField name="errors" type="null | array">
+  `null` on success. `401` when the call belongs to a different organization, `404` when the call does not exist, `403` when the feature is not enabled for your organization.
+</ResponseField>
+
+<RequestExample>
+```bash cURL
+curl -X POST "https://api.bland.ai/v1/calls/{call_id}/transcript-stream/token" \
+  -H "authorization: YOUR_API_KEY"
+```
+</RequestExample>
+
+<ResponseExample>
+```json Response
+{
+  "data": {
+    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+    "expires_in_seconds": 300
+  },
+  "errors": null
+}
+```
+</ResponseExample>
+
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/calls-id-transcript-stream-token.mdx
+++ b/api-v1/post/calls-id-transcript-stream-token.mdx
@@ -10,6 +10,8 @@ Returns a short-lived, ready-to-connect WebSocket URL for the call's [post-trans
 
 The URL is opaque — connect to it exactly as returned. Do not parse it or construct your own.
 
+The URL becomes available when the call is answered (that is when the server handling the call is assigned). Until then this endpoint returns 404 with `NO_ACTIVE_TRANSCRIPT_STREAM`; poll every second or two after placing the call. Once connected, you can hold the socket through the rest of the call — it parks until the transfer starts.
+
 <Note>
   The post-transfer transcript stream is in limited rollout. If this endpoint returns 403 with `FEATURE_NOT_ENABLED`, it is not yet enabled for your organization.
 </Note>
@@ -49,7 +51,7 @@ This endpoint takes no body. POST an empty body or `{}`.
 </ResponseField>
 
 <ResponseField name="errors" type="null | array">
-  `null` on success. `401` when the call belongs to a different organization, `403` when the feature is not enabled for your organization, `404` when the call does not exist or has no active transcript stream (`NO_ACTIVE_TRANSCRIPT_STREAM`: not created with `include_post_transfer_transcript`, or already ended).
+  `null` on success. `401` when the call belongs to a different organization, `403` when the feature is not enabled for your organization, `404` when the call does not exist or has no active transcript stream (`NO_ACTIVE_TRANSCRIPT_STREAM`: not created with `include_post_transfer_transcript`, not yet answered, or already ended).
 </ResponseField>
 
 <RequestExample>

--- a/api-v1/post/calls-id-transcript-stream-token.mdx
+++ b/api-v1/post/calls-id-transcript-stream-token.mdx
@@ -6,9 +6,9 @@ description: "Mint a short-lived JWT for connecting to a call's live post-transf
 
 ## Overview
 
-Mints a short-lived JWT scoped to one call that can be passed as the `token` query parameter when opening the [Post-Transfer Transcript Stream (WebSocket)](/api-v1/post/calls-id-transcript-stream). Use this from your backend so browser clients never see your long-lived API key.
+Returns a short-lived, ready-to-connect WebSocket URL for the call's [post-transfer transcript stream](/api-v1/post/calls-id-transcript-stream). Use this from your backend so browser clients never see your long-lived API key; the returned URL carries only a 5-minute credential scoped to this one call.
 
-Tokens are valid for 5 minutes and only authorize a stream for the call they were minted for. The call must belong to your organization.
+The URL is opaque — connect to it exactly as returned. Do not parse it or construct your own.
 
 <Note>
   The post-transfer transcript stream is in limited rollout. If this endpoint returns 403 with `FEATURE_NOT_ENABLED`, it is not yet enabled for your organization.
@@ -40,16 +40,16 @@ This endpoint takes no body. POST an empty body or `{}`.
 
 ## Response
 
-<ResponseField name="data.token" type="string">
-  JWT to pass as `?token=<token>` on the WebSocket URL.
+<ResponseField name="data.url" type="string">
+  Opaque WebSocket URL. Connect to it as returned, within 5 minutes.
 </ResponseField>
 
 <ResponseField name="data.expires_in_seconds" type="number">
-  Lifetime of the token. Currently `300` (5 minutes). The TTL gates the connection handshake only; an established stream is not closed when the token expires.
+  Lifetime of the URL's embedded credential. Currently `300` (5 minutes). The TTL gates the connection handshake only; an established stream is not closed when it expires.
 </ResponseField>
 
 <ResponseField name="errors" type="null | array">
-  `null` on success. `401` when the call belongs to a different organization, `404` when the call does not exist, `403` when the feature is not enabled for your organization.
+  `null` on success. `401` when the call belongs to a different organization, `403` when the feature is not enabled for your organization, `404` when the call does not exist or has no active transcript stream (`NO_ACTIVE_TRANSCRIPT_STREAM`: not created with `include_post_transfer_transcript`, or already ended).
 </ResponseField>
 
 <RequestExample>
@@ -63,7 +63,7 @@ curl -X POST "https://api.bland.ai/v1/calls/{call_id}/transcript-stream/token" \
 ```json Response
 {
   "data": {
-    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+    "url": "wss://stream.aws.dc8.bland.ai/ws/transcript-stream/eyJhbGciOiJBMjU2R0NNS1ci...?token=eyJhbGciOiJIUzI1NiIs...",
     "expires_in_seconds": 300
   },
   "errors": null

--- a/api-v1/post/calls-id-transcript-stream-token.mdx
+++ b/api-v1/post/calls-id-transcript-stream-token.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Mint Transcript Stream Token"
+title: "Get Transcript Stream URL"
 api: "POST https://api.bland.ai/v1/calls/{call_id}/transcript-stream/token"
 description: "Get a short-lived, ready-to-connect WebSocket URL for a call's live post-transfer transcript stream."
 ---

--- a/api-v1/post/calls-id-transcript-stream-token.mdx
+++ b/api-v1/post/calls-id-transcript-stream-token.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Mint Transcript Stream Token"
 api: "POST https://api.bland.ai/v1/calls/{call_id}/transcript-stream/token"
-description: "Mint a short-lived JWT for connecting to a call's live post-transfer transcript stream."
+description: "Get a short-lived, ready-to-connect WebSocket URL for a call's live post-transfer transcript stream."
 ---
 
 ## Overview

--- a/api-v1/post/calls-id-transcript-stream-token.mdx
+++ b/api-v1/post/calls-id-transcript-stream-token.mdx
@@ -10,7 +10,7 @@ Returns a short-lived, ready-to-connect WebSocket URL for the call's [post-trans
 
 The URL is opaque — connect to it exactly as returned. Do not parse it or construct your own.
 
-The URL becomes available when the call is answered (that is when the server handling the call is assigned). Until then this endpoint returns 404 with `NO_ACTIVE_TRANSCRIPT_STREAM`; poll every second or two after placing the call. Once connected, you can hold the socket through the rest of the call — it parks until the transfer starts.
+The URL becomes available when the call is answered (that is when the server handling the call is assigned). Until then this endpoint returns 404 with `CALL_NOT_FOUND` ("Call was either not found or not started" — the same response as [Listen to Active Call](/api-v1/post/calls-id-listen)); poll every second or two after placing the call. Once connected, you can hold the socket through the rest of the call — it parks until the transfer starts.
 
 <Note>
   The post-transfer transcript stream is in limited rollout. If this endpoint returns 403 with `FEATURE_NOT_ENABLED`, it is not yet enabled for your organization.
@@ -51,7 +51,7 @@ This endpoint takes no body. POST an empty body or `{}`.
 </ResponseField>
 
 <ResponseField name="errors" type="null | array">
-  `null` on success. `401` when the call belongs to a different organization, `403` when the feature is not enabled for your organization, `404` when the call does not exist or has no active transcript stream (`NO_ACTIVE_TRANSCRIPT_STREAM`: not created with `include_post_transfer_transcript`, not yet answered, or already ended).
+  `null` on success. `401` when the call belongs to a different organization, `403` when the feature is not enabled for your organization, `404` with `CALL_NOT_FOUND` when the call does not exist or has no active transcript stream (not created with `include_post_transfer_transcript`, not yet answered, or already ended).
 </ResponseField>
 
 <RequestExample>

--- a/api-v1/post/calls-id-transcript-stream.mdx
+++ b/api-v1/post/calls-id-transcript-stream.mdx
@@ -16,15 +16,11 @@ The stream is a real-time preview. The durable record is the `post_transfer_tran
 
 ---
 
-## Authentication
+## Connecting
 
-Pass a token minted via [Mint Transcript Stream Token](/api-v1/post/calls-id-transcript-stream-token) as the `token` query parameter:
+Request a connection URL from [Mint Transcript Stream Token](/api-v1/post/calls-id-transcript-stream-token) and connect to it exactly as returned, within 5 minutes. The URL is opaque: it routes the connection to the server handling the call and carries the stream credential. Do not parse or reconstruct it.
 
-```
-wss://api.bland.ai/ws/transcript-stream/{call_id}?token=<token>
-```
-
-Connections without a valid token for the call are closed with code `1008`.
+Connections without a valid credential for the call are closed with code `1008`.
 
 ---
 
@@ -106,10 +102,8 @@ const res = await fetch(
 );
 const { data } = await res.json();
 
-// 2. Connect (safe in a browser — the URL carries only the short-lived token)
-const ws = new WebSocket(
-  `wss://api.bland.ai/ws/transcript-stream/${callId}?token=${data.token}`,
-);
+// 2. Connect (safe in a browser — the URL carries only a short-lived credential)
+const ws = new WebSocket(data.url);
 
 ws.onmessage = (event) => {
   const msg = JSON.parse(event.data);

--- a/api-v1/post/calls-id-transcript-stream.mdx
+++ b/api-v1/post/calls-id-transcript-stream.mdx
@@ -26,7 +26,7 @@ Connections without a valid credential for the call are closed with code `1008`.
 
 ## Connection Lifecycle
 
-- **Connect any time after call creation.** A listener that connects before the transfer starts is held and attached automatically when the transferred conversation begins.
+- **Connect any time after the call is answered.** The connection URL becomes mintable once the call is answered; a listener that connects before the transfer starts is held and attached automatically when the transferred conversation begins.
 - **Join-live semantics.** A listener that connects mid-transfer receives segments from that moment forward. There is no history replay; use the post-call webhook for the complete transcript.
 - **Multiple listeners are allowed.** Each mints its own token; all receive the same events.
 - **End of stream.** When the transferred conversation ends, the server sends a `stream_end` event and closes the socket with code `1000`.

--- a/api-v1/post/calls-id-transcript-stream.mdx
+++ b/api-v1/post/calls-id-transcript-stream.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Post-Transfer Transcript Stream (WebSocket)"
-api: "WSS https://api.bland.ai/ws/transcript-stream/{call_id}"
 description: "Live transcript of the conversation after a call is transferred to a human."
 ---
 
@@ -8,7 +7,7 @@ description: "Live transcript of the conversation after a call is transferred to
 
 When a call created with `include_post_transfer_transcript: true` is cold-transferred to a human, Bland transcribes the bridged conversation live. Connect to this WebSocket to receive finalized transcript segments as the caller and the transferred-to representative speak.
 
-The stream is a real-time preview. The durable record is the `post_transfer_transcript` property on the [citations webhook](/api-v1/get/citations), which carries the same segment format built from the call recording after the call ends.
+The stream is a real-time preview. The durable record is the `post_transfer_transcript` property on the [citations webhook](/tutorials/post-call-webhooks#post-transfer-transcript), which carries the same segment format built from the call recording after the call ends.
 
 <Note>
   The post-transfer transcript stream is in limited rollout. If the [Get Transcript Stream URL endpoint](/api-v1/post/calls-id-transcript-stream-token) returns 403, it is not yet enabled for your organization.

--- a/api-v1/post/calls-id-transcript-stream.mdx
+++ b/api-v1/post/calls-id-transcript-stream.mdx
@@ -1,0 +1,127 @@
+---
+title: "Post-Transfer Transcript Stream (WebSocket)"
+api: "WSS https://api.bland.ai/ws/transcript-stream/{call_id}"
+description: "Live transcript of the conversation after a call is transferred to a human."
+---
+
+## Overview
+
+When a call created with `include_post_transfer_transcript: true` is cold-transferred to a human, Bland transcribes the bridged conversation live. Connect to this WebSocket to receive finalized transcript segments as the caller and the transferred-to representative speak.
+
+The stream is a real-time preview. The durable record is the `post_transfer_transcript` property on the [citations webhook](/api-v1/get/citations), which carries the same segment format built from the call recording after the call ends.
+
+<Note>
+  The post-transfer transcript stream is in limited rollout. If the [token mint endpoint](/api-v1/post/calls-id-transcript-stream-token) returns 403, it is not yet enabled for your organization.
+</Note>
+
+---
+
+## Authentication
+
+Pass a token minted via [Mint Transcript Stream Token](/api-v1/post/calls-id-transcript-stream-token) as the `token` query parameter:
+
+```
+wss://api.bland.ai/ws/transcript-stream/{call_id}?token=<token>
+```
+
+Connections without a valid token for the call are closed with code `1008`.
+
+---
+
+## Connection Lifecycle
+
+- **Connect any time after call creation.** A listener that connects before the transfer starts is held and attached automatically when the transferred conversation begins.
+- **Join-live semantics.** A listener that connects mid-transfer receives segments from that moment forward. There is no history replay; use the post-call webhook for the complete transcript.
+- **Multiple listeners are allowed.** Each mints its own token; all receive the same events.
+- **End of stream.** When the transferred conversation ends, the server sends a `stream_end` event and closes the socket with code `1000`.
+
+---
+
+## Events
+
+All messages are JSON text frames.
+
+### `transcript_segment`
+
+One finalized utterance. Segments are settled text — interim results are never sent — so they arrive at natural pause boundaries, not word by word.
+
+```json
+{
+  "event": "transcript_segment",
+  "call_id": "9d404c1b-6a23-4b21-a7f9-64f8456ba0ec",
+  "segment": {
+    "start": 12.4,
+    "end": 15.1,
+    "speaker": 1,
+    "speaker_label": "user",
+    "text": "I was calling about my appointment on Thursday.",
+    "confidence": 0.97
+  }
+}
+```
+
+<ResponseField name="segment.start" type="number">
+  Seconds from the start of the transferred conversation.
+</ResponseField>
+
+<ResponseField name="segment.end" type="number">
+  End of the utterance, in the same clock as `start`.
+</ResponseField>
+
+<ResponseField name="segment.speaker" type="number">
+  `1` for the caller, `2` for the transferred-to human.
+</ResponseField>
+
+<ResponseField name="segment.speaker_label" type="string">
+  `user` for the caller, `representative` for the transferred-to human. Matches the labels in the webhook's `post_transfer_transcript`.
+</ResponseField>
+
+<ResponseField name="segment.text" type="string">
+  The finalized utterance text.
+</ResponseField>
+
+<ResponseField name="segment.confidence" type="number">
+  Transcription confidence between 0 and 1.
+</ResponseField>
+
+Segments from the two speakers can arrive out of chronological order, since each speaker's speech finalizes independently. Order by `start` when rendering.
+
+### `stream_end`
+
+The transferred conversation has ended. No further segments will arrive, and the socket closes with code `1000`.
+
+```json
+{ "event": "stream_end", "call_id": "9d404c1b-6a23-4b21-a7f9-64f8456ba0ec" }
+```
+
+---
+
+## Implementation Example
+
+```javascript
+// 1. Mint a token (server-side)
+const res = await fetch(
+  `https://api.bland.ai/v1/calls/${callId}/transcript-stream/token`,
+  { method: "POST", headers: { authorization: BLAND_API_KEY } },
+);
+const { data } = await res.json();
+
+// 2. Connect (safe in a browser — the URL carries only the short-lived token)
+const ws = new WebSocket(
+  `wss://api.bland.ai/ws/transcript-stream/${callId}?token=${data.token}`,
+);
+
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data);
+  if (msg.event === "transcript_segment") {
+    const s = msg.segment;
+    console.log(`[${s.start}s] ${s.speaker_label}: ${s.text}`);
+  } else if (msg.event === "stream_end") {
+    console.log("Transfer ended");
+  }
+};
+```
+
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/calls-id-transcript-stream.mdx
+++ b/api-v1/post/calls-id-transcript-stream.mdx
@@ -11,14 +11,14 @@ When a call created with `include_post_transfer_transcript: true` is cold-transf
 The stream is a real-time preview. The durable record is the `post_transfer_transcript` property on the [citations webhook](/api-v1/get/citations), which carries the same segment format built from the call recording after the call ends.
 
 <Note>
-  The post-transfer transcript stream is in limited rollout. If the [token mint endpoint](/api-v1/post/calls-id-transcript-stream-token) returns 403, it is not yet enabled for your organization.
+  The post-transfer transcript stream is in limited rollout. If the [Get Transcript Stream URL endpoint](/api-v1/post/calls-id-transcript-stream-token) returns 403, it is not yet enabled for your organization.
 </Note>
 
 ---
 
 ## Connecting
 
-Request a connection URL from [Mint Transcript Stream Token](/api-v1/post/calls-id-transcript-stream-token) and connect to it exactly as returned, within 5 minutes. The URL is opaque: it routes the connection to the server handling the call and carries the stream credential. Do not parse or reconstruct it.
+Request a connection URL from [Get Transcript Stream URL](/api-v1/post/calls-id-transcript-stream-token) and connect to it exactly as returned, within 5 minutes. The URL is opaque: it routes the connection to the server handling the call and carries the stream credential. Do not parse or reconstruct it.
 
 Connections without a valid credential for the call are closed with code `1008`.
 
@@ -26,9 +26,9 @@ Connections without a valid credential for the call are closed with code `1008`.
 
 ## Connection Lifecycle
 
-- **Connect any time after the call is answered.** The connection URL becomes mintable once the call is answered; a listener that connects before the transfer starts is held and attached automatically when the transferred conversation begins.
+- **Connect any time after the call is answered.** The connection URL becomes available once the call is answered; a listener that connects before the transfer starts is held and attached automatically when the transferred conversation begins.
 - **Join-live semantics.** A listener that connects mid-transfer receives segments from that moment forward. There is no history replay; use the post-call webhook for the complete transcript.
-- **Multiple listeners are allowed.** Each mints its own token; all receive the same events.
+- **Multiple listeners are allowed.** Each requests its own connection URL; all receive the same events.
 - **End of stream.** When the transferred conversation ends, the server sends a `stream_end` event and closes the socket with code `1000`.
 
 ---
@@ -95,7 +95,7 @@ The transferred conversation has ended. No further segments will arrive, and the
 ## Implementation Example
 
 ```javascript
-// 1. Mint a token (server-side)
+// 1. Get a connection URL (server-side)
 const res = await fetch(
   `https://api.bland.ai/v1/calls/${callId}/transcript-stream/token`,
   { method: "POST", headers: { authorization: BLAND_API_KEY } },

--- a/api-v1/post/calls.mdx
+++ b/api-v1/post/calls.mdx
@@ -464,6 +464,18 @@ Send an AI phone call with a custom objective and actions. This endpoint can be 
   > Note: Citation schemas are very powerful and accurate, but also are more resource intensive to run. As such, for the time being, they are an enterprise-only feature.
 </ParamField>
 
+<ParamField body="include_post_transfer_transcript" type="boolean" default="false">
+  When `true` and the call is cold-transferred to a human, Bland transcribes the conversation after the transfer and delivers it two ways: live over the [Post-Transfer Transcript Stream](/api-v1/post/calls-id-transcript-stream) WebSocket while the transferred conversation is happening, and post-call as a `post_transfer_transcript` property (plus `transfer_offset_seconds`) on the `citations` webhook event.
+
+  Requires call recording: `record` is enabled automatically when unset, and passing `record: false` alongside this option returns a 400.
+
+  The post-call delivery rides on the citations webhook, so to receive it you also need at least one schema in `citation_schema_ids` and `"citations"` in `webhook_events`.
+
+  <Note>
+    This feature is in limited rollout. If it is not enabled for your organization, the option has no effect.
+  </Note>
+</ParamField>
+
 <ParamField body="post_call_evals" type="object">
   Attach an [evals workbench](/tutorials/evals) to this call. When the call completes, Bland automatically runs the workbench's eval configuration against the call — no separate eval-run submission needed.
 

--- a/docs.json
+++ b/docs.json
@@ -121,6 +121,8 @@
                   "api-v1/post/calls-id-analyze",
                   "api-v1/post/calls-id-stop",
                   "api-v1/post/calls-id-listen",
+                  "api-v1/post/calls-id-transcript-stream-token",
+                  "api-v1/post/calls-id-transcript-stream",
                   "api-v1/post/calls-active-stop",
                   "api-v1/post/calls-active-transfer",
                   "api-v1/get/calls",

--- a/tutorials/post-call-webhooks.mdx
+++ b/tutorials/post-call-webhooks.mdx
@@ -493,6 +493,39 @@ For detailed configuration options and troubleshooting, see the complete [Citati
 
 **Important:** Both the dashboard "Delay post call webhook" toggle AND the `webhook_events` configuration must be properly set for delays to work.
 
+### Post-Transfer Transcript
+
+Calls created with [`include_post_transfer_transcript: true`](/api-v1/post/calls#param-include-post-transfer-transcript) that were cold-transferred to a human carry two additional properties on the `citations` event (in both the standalone and delayed delivery modes):
+
+- `transfer_offset_seconds` — seconds from the start of the call to the transfer.
+- `post_transfer_transcript` — the conversation after the transfer, as speaker-attributed segments. The transferred-to human is `speaker: 2` / `"representative"`; the caller is `speaker: 1` / `"user"`. Timestamps are seconds from the start of the transferred conversation. The `corrected_transcript` continues to contain only the pre-transfer portion of the call.
+
+```json
+{
+  "transfer_offset_seconds": 9.573,
+  "post_transfer_transcript": [
+    {
+      "start": 9.544,
+      "end": 17.804,
+      "speaker": 2,
+      "speaker_label": "representative",
+      "text": "Hi, this is Sam with support. How can I help you today?",
+      "confidence": 0.7
+    },
+    {
+      "start": 18.912,
+      "end": 21.952,
+      "speaker": 1,
+      "speaker_label": "user",
+      "text": "I was calling about my appointment on Thursday.",
+      "confidence": 0.49
+    }
+  ]
+}
+```
+
+The same segment format is available live during the transferred conversation via the [Post-Transfer Transcript Stream](/api-v1/post/calls-id-transcript-stream) WebSocket. This feature is in limited rollout.
+
 ---
 
 ## SMS Conversation Webhooks


### PR DESCRIPTION
- [LOW] **New page: Mint Transcript Stream Token.** `POST /v1/calls/{call_id}/transcript-stream/token` — auth, call ownership, the 403 when the feature is not enabled for the org, response fields, and the note that the 5-minute TTL gates the handshake only.
- [LOW] **New page: Post-Transfer Transcript Stream (WebSocket).** Connection URL and token auth, connect-before-transfer parking, join-live semantics (no history replay), the `transcript_segment` and `stream_end` event formats with field docs, cross-speaker ordering guidance, and a mint-and-connect JavaScript example. Both pages carry a limited-rollout note.
- [LOW] **Both pages added to the Calls nav group** after Listen to Active Call.

Documents the feature shipped in CINTELLILABS/SERVER#9649 (stacked on #9659).

🤖 Generated with [Claude Code](https://claude.com/claude-code)