### PR TITLE
finn/CUS-997/llms-txt-and-claudemd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .DS_Store
-CLAUDE.md
 stripe_llm_example.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# Mintlify documentation
+
+## Working relationship
+- You can push back on ideas. This can lead to better documentation. Cite sources and explain your reasoning when you do
+- ALWAYS ask for clarification rather than making assumptions
+- NEVER lie, guess, or make up anything
+
+## Project context
+- Format: MDX files with YAML frontmatter
+- Config: docs.json for navigation, theme, settings
+- Components: Mintlify components
+- `llms.txt` at the repo root is a hand-maintained index of every page (one bullet per page) plus a curated "About Bland" intro and "Instructions for AI Agents" section. It is not auto-generated. Keep it in sync (see below)
+
+## Content strategy
+- Document just enough for user success. Not too much, not too little
+- Prioritize accuracy and usability
+- Make content evergreen when possible
+- Search for existing content before adding anything new. Avoid duplication unless it is done for a strategic reason
+- Check existing patterns for consistency
+- Start by making the smallest reasonable changes
+
+## docs.json
+- Refer to the [docs.json schema](https://mintlify.com/docs.json) when building the docs.json file and site navigation
+- Every new page must be added to `docs.json` navigation. A page not in navigation is unreachable
+
+## llms.txt maintenance
+Update `llms.txt` whenever you make a structural change to the docs, so AI tools and crawlers stay in sync with the site:
+- **Add a page**: add a bullet under the matching section in the format `- [Title](https://docs.bland.ai/<path>.md): one-line description.` Match the page's frontmatter title and description
+- **Remove a page**: delete its bullet
+- **Rename, move, or repurpose a page**: update the affected URL, title, and description
+- Keep the section a page lives under in `llms.txt` consistent with its group in `docs.json`
+- You do not need to touch `llms.txt` for copy-only edits (typos, rewording) that leave the page's title, description, and path unchanged
+- Changelog pages (`changelog/*`) are intentionally excluded from `llms.txt`. Do not add them
+
+## Frontmatter requirements for pages
+- title: Clear, descriptive page title
+- description: Concise summary for SEO/navigation
+
+## Writing standards
+- Second-person voice ("you")
+- Prerequisites at start of procedural content
+- Test all code examples before publishing
+- Match style and formatting of existing pages
+- Include both basic and advanced use cases
+- Language tags on all code blocks
+- Alt text on all images
+- Relative paths for internal links
+
+## Punctuation and house style
+- NEVER use em dashes (`—`) or the `&mdash;` entity. Rewrite the sentence, or use a colon, period, comma, or parentheses instead
+- Avoid en dashes (`–`) in prose; use "to" for ranges (for example "5 to 10 minutes")
+- Use straight quotes and apostrophes, not curly ones
+- Prefer short, direct sentences over long ones stitched together with dashes or semicolons
+
+## Verify before committing
+- Run `mint dev` locally and confirm changed pages render without errors (install with `npm i -g mint`)
+- Run `mint broken-links` and fix any broken internal links before opening a PR
+- Run `mint a11y` to catch missing alt text and contrast issues on pages you touched
+- Confirm new pages appear in the navigation and in `llms.txt`
+
+## Git workflow
+- NEVER use --no-verify when committing
+- Ask how to handle uncommitted changes before starting
+- Create a new branch when no clear branch exists for changes
+- Commit frequently throughout development
+- NEVER skip or disable pre-commit hooks
+
+## Do not
+- Skip frontmatter on any MDX file
+- Use absolute URLs for internal links
+- Use em dashes anywhere in docs content
+- Include untested code examples
+- Leave a new page out of docs.json navigation or llms.txt
+- Make assumptions. Always ask for clarification

--- a/llms.txt
+++ b/llms.txt
@@ -21,19 +21,19 @@ Bland holds SOC 2 Type II, HIPAA, GDPR, and PCI DSS certifications. Self-hosted 
 ## Core Bland Features
 
 - [Conversational Pathways](https://docs.bland.ai/tutorials/pathways.md): Build node-based conversation flows that give your AI agent structured control over dialogue, branching, and actions.
+- [Norm](https://docs.bland.ai/tutorials/norm.md): Bland's AI assistant for building, editing, testing, and debugging voice agents from a prompt.
 - [Call Logs](https://docs.bland.ai/tutorials/call-logs.md): View, filter, and analyze your call history and transcripts.
 - [Custom Twilio Integration](https://docs.bland.ai/tutorials/custom-twilio.md): Connect Bland to your own Twilio account for phone number management.
 - [Webhooks](https://docs.bland.ai/tutorials/webhooks.md): Configure outbound API requests inside pathways using the webhook node to retrieve data or trigger workflows during live calls.
-- [Tools](https://docs.bland.ai/tutorials/v2-tools.md): Give your AI agent the ability to take actions during live calls by connecting to external APIs and services.
-- [Custom Tools (Legacy)](https://docs.bland.ai/tutorials/tools.md): The legacy custom tools system; use the v2 Tools API for new integrations.
+- [Tools](https://docs.bland.ai/tutorials/tools/overview.md): Give your AI agent the ability to take actions during live calls by connecting to external APIs and services.
+- [Tools: Integration Tools](https://docs.bland.ai/tutorials/tools/integration-tools.md): Connect to Cal.com, Salesforce, Slack, and other services using built-in integrations.
+- [Tools: Custom API Integration](https://docs.bland.ai/tutorials/tools/custom-api.md): Create tools that call your own backend, internal services, or any HTTP endpoint.
 - [Secrets](https://docs.bland.ai/tutorials/secrets.md): Securely store and reference API keys and credentials in your workflows without hardcoding them.
 - [BTTS v2 Voice Cloning](https://docs.bland.ai/tutorials/btts.md): Create, configure, and optimize voice clones for your AI agents.
 
 ## Basic Tutorials
 
 - [Batch Calls](https://docs.bland.ai/tutorials/batch-calls.md): Send a batch of calls to a CSV of recipients simultaneously.
-- [Tools: Integration Tools](https://docs.bland.ai/tutorials/v2-tools-built-in.md): Connect to Cal.com, Salesforce, Slack, and other services using built-in integrations.
-- [Tools: Custom API Integration](https://docs.bland.ai/tutorials/v2-tools-custom-api.md): Create tools that call your own backend, internal services, or any HTTP endpoint.
 
 ## Advanced Features
 
@@ -43,11 +43,15 @@ Bland holds SOC 2 Type II, HIPAA, GDPR, and PCI DSS certifications. Self-hosted 
 - [Guard Rails](https://docs.bland.ai/tutorials/guard-rails.md): Automated monitoring that runs continuously on every AI response to catch critical failures before they reach customers.
 - [Post Call Webhooks](https://docs.bland.ai/tutorials/post-call-webhooks.md): Trigger HTTP requests after a call ends to process transcripts, sync CRM data, or kick off downstream workflows.
 - [Webhook Signing](https://docs.bland.ai/tutorials/webhook-signing.md): Verify the authenticity of Bland webhook payloads using HMAC signature validation.
-- [Personas](https://docs.bland.ai/tutorials/personas.md): Create unified AI agents that manage phone numbers and use cases — build once, use everywhere.
+- [Personas](https://docs.bland.ai/tutorials/personas.md): Create unified AI agents that manage phone numbers and use cases. Build once, use everywhere.
 - [Web Chat Widget](https://docs.bland.ai/tutorials/chat-widget.md): Embed a voice and chat widget on your website to let visitors speak or chat with your AI agent.
 - [Outcomes](https://docs.bland.ai/tutorials/outcomes.md): Combine pathway tags, citations, and call metadata to define what happened on each call.
 - [Blocked Numbers](https://docs.bland.ai/tutorials/blocked-numbers.md): Manage and configure blocked phone numbers in the Bland dashboard.
 - [Memory](https://docs.bland.ai/tutorials/memories.md): Preserve context across conversations by enabling memory on your pathway or persona.
+- [Flex Mode](https://docs.bland.ai/tutorials/flex-mode.md): Let your agent choose where to go next based on the conversation, instead of strictly following the edges between nodes.
+- [Evals](https://docs.bland.ai/tutorials/evals.md): Grade real calls for quality at scale using configurable LLM judges.
+- [Live Translation](https://docs.bland.ai/tutorials/translation.md): Stream audio and receive translated audio back in real time.
+- [Alerts](https://docs.bland.ai/tutorials/alerts.md): Monitor agent behavior in real time with thresholds on built-in call metrics or custom conditions, routed to email, phone, or a custom tool.
 
 ## Platform Information
 
@@ -58,17 +62,20 @@ Bland holds SOC 2 Type II, HIPAA, GDPR, and PCI DSS certifications. Self-hosted 
 - [Command Line Interface](https://docs.bland.ai/sdks/cli.md): Manage your Bland account from the terminal: make calls, build and test pathways, configure phone numbers, and more.
 - [Dev Terminal](https://docs.bland.ai/sdks/dev-terminal.md): An interactive AI-powered REPL for building, testing, and deploying phone agents without leaving your terminal.
 - [Web Agent SDK](https://docs.bland.ai/sdks/web-agent-sdk.md): Embed a Bland voice agent into any web application with secure, token-based authentication.
+- [Bland TTS](https://docs.bland.ai/sdks/bland-tts.md): A focused TTS and voice toolkit for Bland: CLI, Node library, and MCP server in one lightweight package.
 
 ## Bland Enterprise
 
 - [Infrastructure & Releases](https://docs.bland.ai/enterprise-features/infrastructure-and-releases.md): Dedicated infrastructure, version-controlled releases, and canary deployments for enterprise customers.
-- [Twilio Studio Flow Integration](https://docs.bland.ai/enterprise-features/studio-flow-integration.md): Integrate Bland within Twilio Studio Flows.
 - [Custom Dialing](https://docs.bland.ai/enterprise-features/custom-dialing.md): Maximize outbound call pickup rates by dynamically selecting the optimal number from your phone number inventory.
 - [Citations](https://docs.bland.ai/enterprise-features/citations.md): Extract structured insights from post-call transcripts using custom schemas.
 - [Scheduling Node](https://docs.bland.ai/enterprise-features/scheduling-node.md): Enable intelligent meeting scheduling within conversational pathways using webhook integration.
 - [Custom Code Node](https://docs.bland.ai/enterprise-features/custom-code-node.md): Execute custom JavaScript code within conversational pathways.
 - [Warm Transfer](https://docs.bland.ai/tutorials/warm-transfer.md): Live human agent transfers facilitated by Bland.
-- [Messaging](https://docs.bland.ai/tutorials/sms.md): Use SMS and RCS to create a personal contact that users can call and text.
+- [Messaging](https://docs.bland.ai/tutorials/messaging/overview.md): Run conversational agents over SMS, RCS, and iMessage from one stack, powered by the same pathways, personas, and memory you use for voice.
+- [iMessage](https://docs.bland.ai/tutorials/messaging/imessage.md): Run a branded iMessage agent that can send and receive photos, videos, files, voice memos, tapbacks, and more.
+- [RCS](https://docs.bland.ai/tutorials/messaging/rcs.md): Rich Communication Services in Bland: verified business profile, suggested replies, action buttons, cards, and media via the same APIs as SMS.
+- [SMS](https://docs.bland.ai/tutorials/messaging/sms.md): SMS specifics in Bland: A2P registration, bring-your-own-Twilio, and pricing.
 - [SIP Integration](https://docs.bland.ai/enterprise-features/SIP-integration.md): Configure and manage SIP for call routing to and from Bland, with guided setup, auto-discovery, test calls, and number porting.
 - [SSO Support](https://docs.bland.ai/enterprise-features/SSO.md): Configure Single Sign-On using OIDC or SAML 2.0 with your identity provider.
 - [JWT Signature Configuration](https://docs.bland.ai/enterprise-features/jwt-authentication.md): Asymmetric JWT signing for enterprise-grade webhook and request authentication.
@@ -186,6 +193,16 @@ Generate speech from text, manage Bland TTS voices, and clone custom voices. The
 - [Discover Sitemap URLs](https://docs.bland.ai/api-v1/post/knowledge-crawl.md): Discover URLs from a website's sitemap for web scraping.
 - [Chat with Knowledge Base](https://docs.bland.ai/api-v1/post/knowledge-chat.md): Perform a conversational query against knowledge bases with context.
 
+### Vector Knowledge Bases (Deprecated)
+
+- [Create Knowledge Base](https://docs.bland.ai/api-v1/post/vectors.md): Create a new knowledge base.
+- [Upload Media](https://docs.bland.ai/api-v1/post/upload-media.md): Upload a media file as a new knowledge base.
+- [Upload Text](https://docs.bland.ai/api-v1/post/upload-text.md): Upload a text file as a new knowledge base.
+- [Update Knowledge Base](https://docs.bland.ai/api-v1/patch/vectors-id.md): Update a knowledge base.
+- [List Knowledge Bases](https://docs.bland.ai/api-v1/get/vectors.md): List all knowledge bases in your account.
+- [Get Knowledge Base Details](https://docs.bland.ai/api-v1/get/vectors-id.md): View the details for a specific knowledge base.
+- [Delete Knowledge Base](https://docs.bland.ai/api-v1/delete/vectors-id.md): Remove a knowledge base from your account.
+
 ## API Reference: Numbers
 
 - [Purchase Phone Number](https://docs.bland.ai/api-v1/post/inbound-purchase.md): Purchase a new phone number ($15/mo).
@@ -250,6 +267,21 @@ Generate speech from text, manage Bland TTS voices, and clone custom voices. The
 - [Reset Contact Memory](https://docs.bland.ai/api-v1/post/memory-reset.md): Permanently delete all memory for a contact scoped to a specific persona or agent number.
 - [Enable or Disable Memory](https://docs.bland.ai/api-v1/post/memory-enable.md): Enable or disable memory for a pathway or persona version.
 
+### Memory Store (Legacy)
+
+- [List All Memories](https://docs.bland.ai/api-v1/get/memory.md): Retrieve all memory stores associated with your account.
+- [Get Memory Details](https://docs.bland.ai/api-v1/get/memory-memory-id.md): Retrieve detailed information about a specific memory store and its users.
+- [Create Memory](https://docs.bland.ai/api-v1/post/memory-create.md): Create a new memory to organize and track call interactions by phone numbers.
+- [Update Memory](https://docs.bland.ai/api-v1/post/memory-memory-id-update.md): Update the name of an existing memory.
+- [Delete Memory](https://docs.bland.ai/api-v1/post/memory-memory-id-delete.md): Permanently delete an entire memory and all associated data including users, calls, and metadata.
+- [Get User Memory Details](https://docs.bland.ai/api-v1/post/memory-memory-id-user.md): Retrieve detailed memory information for a specific user or phone number in a memory store.
+- [Search User Calls in Memory](https://docs.bland.ai/api-v1/post/memory-memory-id-user-search.md): Retrieve call history and data for a specific user or phone number within a memory.
+- [Add User to Memory](https://docs.bland.ai/api-v1/post/memory-memory-id-add-user.md): Add a new user or phone number to an existing memory.
+- [Update User Memory Data](https://docs.bland.ai/api-v1/post/memory-memory-id-user-update.md): Update the metadata and summary information for a specific user within a memory.
+- [Remove User from Memory](https://docs.bland.ai/api-v1/post/memory-memory-id-user-delete.md): Remove a specific user or phone number and all their associated data from a memory.
+- [Add Call to Memory](https://docs.bland.ai/api-v1/post/memory-memory-id-add-call.md): Add an existing call to a memory.
+- [Remove Call from Memory](https://docs.bland.ai/api-v1/post/memory-memory-id-call-call-id-delete.md): Remove a specific call from a memory.
+
 ## API Reference: Node Tests
 
 - [Get Node Test Run](https://docs.bland.ai/api-v1/get/node_test_run.md): Retrieve a node test run.
@@ -279,6 +311,68 @@ Generate speech from text, manage Bland TTS voices, and clone custom voices. The
 - [Get Active Tornado Session](https://docs.bland.ai/api-v1/get/agent-testing-tornado-active.md): Get the currently active tornado session for a pathway.
 - [Get Tornado Status](https://docs.bland.ai/api-v1/get/agent-testing-tornado-status.md): Get detailed progress for a tornado session including iteration data and fix plans.
 - [Cancel Tornado Session](https://docs.bland.ai/api-v1/post/agent-testing-tornado-cancel.md): Cancel a running tornado session.
+
+## API Reference: Evals
+
+Grade real calls for quality at scale using configurable LLM judges.
+
+- [Get Evals Status](https://docs.bland.ai/api-v1/get/evals-status.md): Check whether the Evals feature is enabled for your organization.
+
+### Eval Agents
+
+- [List Eval Agents](https://docs.bland.ai/api-v1/get/evals-agents.md): List the eval agents in your organization.
+- [Create Eval Agent](https://docs.bland.ai/api-v1/post/evals-agents.md): Create a new eval agent, optionally seeded from a template.
+- [Get Eval Agent](https://docs.bland.ai/api-v1/get/evals-agents-id.md): Fetch one eval agent and its current draft version.
+- [Update Eval Agent](https://docs.bland.ai/api-v1/patch/evals-agents-id.md): Update an eval agent's metadata or repoint its active version.
+- [Delete Eval Agent](https://docs.bland.ai/api-v1/delete/evals-agents-id.md): Soft-delete an eval agent.
+- [Publish Eval Agent](https://docs.bland.ai/api-v1/post/evals-agents-id-publish.md): Publish the agent's current draft as a new active version.
+
+### Eval Agent Versions
+
+- [List Eval Agent Versions](https://docs.bland.ai/api-v1/get/evals-agents-id-versions.md): List all versions of an eval agent.
+- [Create Eval Agent Version](https://docs.bland.ai/api-v1/post/evals-agents-id-versions.md): Fork a new editable draft version of an eval agent.
+- [Get Eval Agent Version](https://docs.bland.ai/api-v1/get/evals-agents-id-versions-id.md): Fetch one version of an eval agent.
+- [Update Eval Agent Version](https://docs.bland.ai/api-v1/patch/evals-agents-id-versions-id.md): Edit a draft version's prompt, levels, targets, or weight.
+
+### Experiments
+
+- [List Eval Runs](https://docs.bland.ai/api-v1/get/evals-runs.md): List eval runs in your organization, with optional filters.
+- [Create Eval Run](https://docs.bland.ai/api-v1/post/evals-runs.md): Start a new eval run over a batch of calls.
+- [Estimate Eval Run](https://docs.bland.ai/api-v1/post/evals-runs-estimates.md): Preview the size and cost of a run before starting it.
+- [Get Eval Run](https://docs.bland.ai/api-v1/get/evals-runs-id.md): Fetch one eval run and its current status and summary.
+- [Cancel Eval Run](https://docs.bland.ai/api-v1/post/evals-runs-id-cancel.md): Cancel a pending or running eval run.
+
+### Experiment Results
+
+- [List Call Results](https://docs.bland.ai/api-v1/get/evals-runs-id-call-results.md): List the per-call results for an eval run.
+- [List Agent Results](https://docs.bland.ai/api-v1/get/evals-runs-id-agent-results.md): List every individual judge verdict in an eval run.
+- [List Agent Snapshots](https://docs.bland.ai/api-v1/get/evals-runs-id-agent-snapshots.md): List the frozen agent configurations a run scored against.
+
+### Workbench Setups
+
+- [List Workbench Setups](https://docs.bland.ai/api-v1/get/evals-workbench-setups.md): List the workbench setups in your organization.
+- [Create Workbench Setup](https://docs.bland.ai/api-v1/post/evals-workbench-setups.md): Create a new workbench setup with an empty draft version.
+- [Get Workbench Setup](https://docs.bland.ai/api-v1/get/evals-workbench-setups-id.md): Fetch one workbench setup and its current draft version.
+- [Update Workbench Setup](https://docs.bland.ai/api-v1/patch/evals-workbench-setups-id.md): Update a workbench setup's metadata or repoint its active version.
+- [Delete Workbench Setup](https://docs.bland.ai/api-v1/delete/evals-workbench-setups-id.md): Soft-delete a workbench setup.
+- [Publish Workbench Setup](https://docs.bland.ai/api-v1/post/evals-workbench-setups-id-publish.md): Publish the setup's current draft as a new active version.
+
+### Workbench Setup Versions
+
+- [List Workbench Setup Versions](https://docs.bland.ai/api-v1/get/evals-workbench-setups-id-versions.md): List all versions of a workbench setup.
+- [Create Workbench Setup Version](https://docs.bland.ai/api-v1/post/evals-workbench-setups-id-versions.md): Fork a new editable draft version of a workbench setup.
+- [Get Workbench Setup Version](https://docs.bland.ai/api-v1/get/evals-workbench-setups-id-versions-id.md): Fetch one version of a workbench setup.
+- [Update Workbench Setup Version](https://docs.bland.ai/api-v1/patch/evals-workbench-setups-id-versions-id.md): Edit a draft version's attached agents, threshold, run mode, or default calls.
+
+### Eval Templates
+
+- [List Eval Agent Templates](https://docs.bland.ai/api-v1/get/evals-agent-templates.md): List the read-only library of shipped eval agent templates.
+- [Get Eval Agent Template](https://docs.bland.ai/api-v1/get/evals-agent-templates-key.md): Fetch a single shipped eval agent template by its key.
+- [List User Templates](https://docs.bland.ai/api-v1/get/evals-user-templates.md): List your organization's saved eval agent templates.
+- [Create User Template](https://docs.bland.ai/api-v1/post/evals-user-templates.md): Save a new eval agent template, from scratch or by snapshotting an existing eval agent.
+- [Get User Template](https://docs.bland.ai/api-v1/get/evals-user-templates-id.md): Fetch one of your organization's saved eval agent templates.
+- [Update User Template](https://docs.bland.ai/api-v1/patch/evals-user-templates-id.md): Update a saved eval agent template. The source pointers cannot be changed.
+- [Delete User Template](https://docs.bland.ai/api-v1/delete/evals-user-templates-id.md): Soft-delete a saved eval agent template.
 
 ## API Reference: Guard Rails
 
@@ -354,6 +448,12 @@ Generate speech from text, manage Bland TTS voices, and clone custom voices. The
 - [Get Post Conversation Webhook](https://docs.bland.ai/api-v1/get/sms-conversations-webhook.md): Retrieve the webhook delivery log for an SMS conversation.
 - [SMS Conversation Analysis](https://docs.bland.ai/api-v1/post/sms-analyze.md): Answer questions and extract information from an SMS conversation.
 
+## API Reference: Live Translation
+
+- [Create Translation Session](https://docs.bland.ai/api-v1/post/translation-sessions.md): Create a real-time translation session and receive a WebSocket URL for streaming audio.
+- [Get Translation Session](https://docs.bland.ai/api-v1/get/translation-sessions-id.md): Retrieve the status, duration, and billing details of a translation session.
+- [End Translation Session](https://docs.bland.ai/api-v1/delete/translation-sessions-id.md): Terminate a translation session from the server side.
+
 ## API Reference: SIP Trunks
 
 - [Get SIP Config](https://docs.bland.ai/api-v1/get/sip-config.md): Retrieve the current SIP configuration for a phone number.
@@ -375,6 +475,8 @@ Generate speech from text, manage Bland TTS voices, and clone custom voices. The
 - [Initiate Port Request](https://docs.bland.ai/api-v1/post/sip-port-initiate.md): Submit a number porting request to transfer phone numbers to Bland.
 - [List Port Requests](https://docs.bland.ai/api-v1/get/sip-port-requests.md): List all number porting requests for your organization.
 - [Cancel Port Request](https://docs.bland.ai/api-v1/delete/sip-port-cancel.md): Cancel an in-progress number porting request.
+- [Parse SIP Destination](https://docs.bland.ai/api-v1/post/sip-parse-destination.md): Parse and validate a raw SIP destination string into its host, port, user, and transport before attaching it to a trunk.
+- [Generate SIP Password](https://docs.bland.ai/api-v1/get/sip-generate-password.md): Generate a strong, PBX-safe SIP password for register-based authentication, at a configurable length.
 
 ## API Reference: Custom Dialing Pools
 
@@ -452,9 +554,9 @@ Issues capture problems found on calls, bundle the evidence (calls, SMS conversa
 
 As an AI agent integrating with Bland, prefer Conversational Pathways for any multi-turn or branching call flow. For simple one-off calls, pass a `task` string directly to `POST /v1/calls`. For structured flows, always use a `pathway_id`.
 
-Use the v2 Tools API (`POST /v2/tools`) for all new tool integrations — never the legacy Custom Tools (`POST /v1/tools`). Tools can call any HTTP endpoint and inject the response back into the live conversation. Store credentials using Secrets and reference them by name in tool configurations rather than hardcoding values.
+Use the v2 Tools API (`POST /v2/tools`) for all new tool integrations, never the legacy Custom Tools (`POST /v1/tools`). Tools can call any HTTP endpoint and inject the response back into the live conversation. Store credentials using Secrets and reference them by name in tool configurations rather than hardcoding values.
 
-For inbound calls, purchase a number and attach it to a pathway or persona via the inbound API. Personas are the recommended abstraction when managing multiple phone numbers with a shared agent identity — configure the persona once and attach any number of phone numbers to it.
+For inbound calls, purchase a number and attach it to a pathway or persona via the inbound API. Personas are the recommended abstraction when managing multiple phone numbers with a shared agent identity. Configure the persona once and attach any number of phone numbers to it.
 
 For testing, use the Testbed to iterate on node prompts with real call data and Standards to lock in regression-tested behavior. Run Scenarios for automated end-to-end pathway validation before deploying changes. Enable Guard Rails in production to continuously monitor every AI response for critical failures.
 
@@ -464,4 +566,4 @@ When voice is important, use BTTS v2 to create a voice clone. Reference the clon
 
 For batch outbound campaigns, use `POST /v2/batches` with a recipient list. Monitor batch progress with `GET /v2/batches/{id}` and stop a running batch with `POST /v2/batches/{id}/stop`.
 
-Never hardcode phone numbers into test scripts — use the Bland dashboard or CLI to manage numbers. Always check the API Reference at https://docs.bland.ai/api-v1/post/calls for the full parameter list when sending calls.
+Never hardcode phone numbers into test scripts. Use the Bland dashboard or CLI to manage numbers. Always check the API Reference at https://docs.bland.ai/api-v1/post/calls for the full parameter list when sending calls.


### PR DESCRIPTION
## What

Two related changes to keep our contributor guidance and AI index accurate.

### 1. Strengthen and track `CLAUDE.md`
- **Un-ignore `CLAUDE.md`** (removed from `.gitignore`) so the rules reach every contributor and their agents, instead of living only on one machine.
- Added a **punctuation / house-style** section: hard ban on em dashes (`—` / `&mdash;`), en-dash guidance, straight quotes.
- Added **`llms.txt` maintenance** rules: keep the index in sync on structural page changes (add/remove/rename), with changelog pages explicitly excluded.
- Added **pre-commit verification** steps (`mint dev`, `mint broken-links`, `mint a11y`) and a requirement that new pages land in both `docs.json` navigation and `llms.txt`.

### 2. Sync `llms.txt` with the current docs
The index had drifted since June. This brings it fully current (excluding changelog by convention):
- **Fixed stale links:** Tools pages moved to `tutorials/tools/*`, SMS to `tutorials/messaging/sms`; removed the deleted Studio Flow page.
- **Added missing pages:** Norm, Flex Mode, Evals, Live Translation, Alerts, Bland TTS SDK, the Messaging suite (SMS/RCS/iMessage), restructured Tools.
- **Added missing API sections:** full Evals API, Live Translation, Vector Knowledge Bases (deprecated), Memory Store (legacy), two SIP endpoints.
- **Removed the 4 em dashes** to match the new house style.

## Verification
- 0 em dashes in `llms.txt`.
- Every listed slug resolves to a real file (372 entries).
- No non-changelog nav page missing; no stale links remain.

Descriptions were pulled from each page's frontmatter, reworded only where the source used an em dash or ran long.