### PR TITLE
Surface the limited-rollout note on the post-transfer webhook section

### DIFF
--- a/tutorials/post-call-webhooks.mdx
+++ b/tutorials/post-call-webhooks.mdx
@@ -495,6 +495,10 @@ For detailed configuration options and troubleshooting, see the complete [Citati
 
 ### Post-Transfer Transcript
 
+<Note>
+  The post-transfer transcript is in limited rollout. If it is not enabled for your organization, these properties are absent.
+</Note>
+
 Calls created with [`include_post_transfer_transcript: true`](/api-v1/post/calls#param-include-post-transfer-transcript) that were cold-transferred to a human carry two additional properties on the `citations` event (in both the standalone and delayed delivery modes):
 
 - `transfer_offset_seconds` — seconds from the start of the call to the transfer.
@@ -524,7 +528,7 @@ Calls created with [`include_post_transfer_transcript: true`](/api-v1/post/calls
 }
 ```
 
-The same segment format is available live during the transferred conversation via the [Post-Transfer Transcript Stream](/api-v1/post/calls-id-transcript-stream) WebSocket. This feature is in limited rollout.
+The same segment format is available live during the transferred conversation via the [Post-Transfer Transcript Stream](/api-v1/post/calls-id-transcript-stream) WebSocket.
 
 ---
 


### PR DESCRIPTION
The rollout caveat was a trailing sentence after the JSON example, easy to miss; it is now a Note callout at the top of the section, matching the stream pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)