### PR TITLE
docs: rename item-sense "Knowledge Base" to "knowledge base item"

### DIFF
--- a/api-v1/delete/knowledge-id.mdx
+++ b/api-v1/delete/knowledge-id.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Delete Knowledge Base"
+title: "Delete Knowledge Base Item"
 api: "DELETE https://api.bland.ai/v1/knowledge/{knowledge_base_id}"
-description: "Soft deletes a knowledge base by setting its status to 'DELETED'."
+description: "Soft deletes a knowledge base item by setting its status to 'DELETED'."
 ---
 
-Marks a knowledge base as deleted by setting its status to `"DELETED"`. This is a soft delete operation - the knowledge base data is retained but becomes inaccessible for normal operations.
+Marks a knowledge base item as deleted by setting its status to `"DELETED"`. This is a soft delete operation - the knowledge base item data is retained but becomes inaccessible for normal operations.
 
 ### Headers
 
@@ -15,7 +15,7 @@ Marks a knowledge base as deleted by setting its status to `"DELETED"`. This is 
 ### Path Parameters
 
 <ParamField path="knowledge_base_id" type="string" required>
-  The unique identifier of the knowledge base to delete.
+  The unique identifier of the knowledge base item to delete.
 </ParamField>
 
 ### Response
@@ -32,7 +32,7 @@ Marks a knowledge base as deleted by setting its status to `"DELETED"`. This is 
   </ResponseField>
 
   <ResponseField name="data.knowledge_base_id" type="string">
-    The ID of the deleted knowledge base.
+    The ID of the deleted knowledge base item.
   </ResponseField>
 </ResponseField>
 

--- a/api-v1/delete/vectors-id.mdx
+++ b/api-v1/delete/vectors-id.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Delete Knowledge Base" 
+title: "Delete Knowledge Base Item" 
 api: "DELETE https://api.bland.ai/v1/knowledgebases/{vector_id}"
-description: "Remove a knowledge base from your account."
+description: "Remove a knowledge base item from your account."
 ---
 
 ### Headers
@@ -13,7 +13,7 @@ description: "Remove a knowledge base from your account."
 ### Path Parameters
 
 <ParamField path="vector_id" type="string" required>
-    The `vector_id` of the knowledge base to delete.
+    The `vector_id` of the knowledge base item to delete.
 </ParamField>
 
 <ResponseExample>

--- a/api-v1/get/all_pathway.mdx
+++ b/api-v1/get/all_pathway.mdx
@@ -179,7 +179,7 @@ description: "Returns a set of information about all the conversational pathways
       - `transferNumber`
         - If the node is a transfer node, this is the number to which the call will be transferred.
       - `kb`
-        - If the node is a knowledge base node, this is the knowledge base that will be used.
+        - If the node is a knowledge base node, this is the knowledge base item that will be used.
       - `pathwayExamples`
         - The fine-tuning examples for the agent at this node for the pathways chosen
       - `conditionExamples`

--- a/api-v1/get/knowledge-id.mdx
+++ b/api-v1/get/knowledge-id.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Get Knowledge Base"
+title: "Get Knowledge Base Item"
 api: "GET https://api.bland.ai/v1/knowledge/{knowledge_base_id}"
-description: "Retrieves a specific knowledge base by ID."
+description: "Retrieves a specific knowledge base item by ID."
 ---
 
-Returns detailed information about a specific knowledge base, including its current status, metadata, and file information (if applicable).
+Returns detailed information about a specific knowledge base item, including its current status, metadata, and file information (if applicable).
 
 ### Headers
 
@@ -15,24 +15,24 @@ Returns detailed information about a specific knowledge base, including its curr
 ### Path Parameters
 
 <ParamField path="knowledge_base_id" type="string" required>
-  The unique identifier of the knowledge base to retrieve.
+  The unique identifier of the knowledge base item to retrieve.
 </ParamField>
 
 ### Response
 
 <ResponseField name="data" type="object">
-  The knowledge base object.
+  The knowledge base item object.
 
   <ResponseField name="data.id" type="string">
-    Unique identifier for the knowledge base.
+    Unique identifier for the knowledge base item.
   </ResponseField>
 
   <ResponseField name="data.name" type="string">
-    Name of the knowledge base.
+    Name of the knowledge base item.
   </ResponseField>
 
   <ResponseField name="data.description" type="string">
-    Description of the knowledge base (if provided).
+    Description of the knowledge base item (if provided).
   </ResponseField>
 
   <ResponseField name="data.status" type="string">
@@ -40,7 +40,7 @@ Returns detailed information about a specific knowledge base, including its curr
   </ResponseField>
 
   <ResponseField name="data.type" type="string">
-    Type of knowledge base: `"FILE"`, `"WEB_SCRAPE"`, or `"TEXT"`.
+    Type of knowledge base item: `"FILE"`, `"WEB_SCRAPE"`, or `"TEXT"`.
   </ResponseField>
 
   <ResponseField name="data.source_urls" type="string">
@@ -64,7 +64,7 @@ Returns detailed information about a specific knowledge base, including its curr
   </ResponseField>
 
   <ResponseField name="data.file" type="object">
-    File information for file-type knowledge bases.
+    File information for file-type knowledge base items.
 
     <ResponseField name="data.file.file_name" type="string">
       Original filename.

--- a/api-v1/get/knowledge.mdx
+++ b/api-v1/get/knowledge.mdx
@@ -1,10 +1,10 @@
 ---
-title: "List Knowledge Bases"
+title: "List Knowledge Base Items"
 api: "GET https://api.bland.ai/v1/knowledge"
-description: "Retrieves a paginated list of knowledge bases for the authenticated organization."
+description: "Retrieves a paginated list of knowledge base items for the authenticated organization."
 ---
 
-Returns all knowledge bases in your organization with pagination support. Use this endpoint to browse your available knowledge bases and their current status.
+Returns all knowledge base items in your organization with pagination support. Use this endpoint to browse your available knowledge base items and their current status.
 
 ### Headers
 
@@ -25,21 +25,21 @@ Returns all knowledge bases in your organization with pagination support. Use th
 ### Response
 
 <ResponseField name="data" type="object">
-  Paginated list of knowledge bases.
+  Paginated list of knowledge base items.
 
   <ResponseField name="data.kbs" type="array">
-    Array of knowledge base objects.
+    Array of knowledge base item objects.
 
     <ResponseField name="data.kbs[].id" type="string">
-      Unique identifier for the knowledge base.
+      Unique identifier for the knowledge base item.
     </ResponseField>
 
     <ResponseField name="data.kbs[].name" type="string">
-      Name of the knowledge base.
+      Name of the knowledge base item.
     </ResponseField>
 
     <ResponseField name="data.kbs[].description" type="string">
-      Description of the knowledge base (if provided).
+      Description of the knowledge base item (if provided).
     </ResponseField>
 
     <ResponseField name="data.kbs[].status" type="string">
@@ -47,7 +47,7 @@ Returns all knowledge bases in your organization with pagination support. Use th
     </ResponseField>
 
     <ResponseField name="data.kbs[].type" type="string">
-      Type of knowledge base: `"FILE"`, `"WEB_SCRAPE"`, or `"TEXT"`.
+      Type of knowledge base item: `"FILE"`, `"WEB_SCRAPE"`, or `"TEXT"`.
     </ResponseField>
 
     <ResponseField name="data.kbs[].source_urls" type="string">
@@ -71,7 +71,7 @@ Returns all knowledge bases in your organization with pagination support. Use th
     </ResponseField>
 
     <ResponseField name="data.kbs[].file" type="object">
-      File information for file-type knowledge bases.
+      File information for file-type knowledge base items.
 
       <ResponseField name="data.kbs[].file.file_name" type="string">
         Original filename.
@@ -88,7 +88,7 @@ Returns all knowledge bases in your organization with pagination support. Use th
   </ResponseField>
 
   <ResponseField name="data.total" type="number">
-    Total number of knowledge bases in the organization.
+    Total number of knowledge base items in the organization.
   </ResponseField>
 </ResponseField>
 

--- a/api-v1/get/pathway.mdx
+++ b/api-v1/get/pathway.mdx
@@ -185,7 +185,7 @@ description: "Returns a set of information about the conversational pathway in y
       - `transferNumber`
         - If the node is a transfer node, this is the number to which the call will be transferred.
       - `kb`
-        - If the node is a knowledge base node, this is the knowledge base that will be used.
+        - If the node is a knowledge base node, this is the knowledge base item that will be used.
       - `pathwayExamples`
         - The fine-tuning examples for the agent at this node for the pathways chosen
       - `conditionExamples`

--- a/api-v1/get/personas-id-versions-version-id.mdx
+++ b/api-v1/get/personas-id-versions-version-id.mdx
@@ -48,7 +48,7 @@ description: "Retrieve a specific persona version."
       Array of pathway routing conditions (null if none).
     </ResponseField>
     <ResponseField name="kb_ids" type="array">
-      Array of knowledge base IDs connected to this version.
+      Array of knowledge base item IDs connected to this version.
     </ResponseField>
     <ResponseField name="call_config" type="object">
       Call configuration settings (null if none).

--- a/api-v1/get/personas-id-versions.mdx
+++ b/api-v1/get/personas-id-versions.mdx
@@ -44,7 +44,7 @@ description: "Retrieve all versions of a specific persona."
       Array of pathway routing conditions (null if none).
     </ResponseField>
     <ResponseField name="kb_ids" type="array">
-      Array of knowledge base IDs connected to this version.
+      Array of knowledge base item IDs connected to this version.
     </ResponseField>
     <ResponseField name="call_config" type="object">
       Call configuration settings (null if none).

--- a/api-v1/get/personas-id.mdx
+++ b/api-v1/get/personas-id.mdx
@@ -86,7 +86,7 @@ description: "Retrieve a specific persona."
           Array of pathway routing conditions.
         </ResponseField>
         <ResponseField name="kb_ids" type="array">
-          Array of knowledge base IDs.
+          Array of knowledge base item IDs.
         </ResponseField>
         <ResponseField name="call_config" type="object">
           Call configuration settings.

--- a/api-v1/get/personas.mdx
+++ b/api-v1/get/personas.mdx
@@ -91,7 +91,7 @@ description: "Retrieve a list of all personas in your organization."
           Array of pathway routing conditions.
         </ResponseField>
         <ResponseField name="kb_ids" type="array">
-          Array of knowledge base IDs.
+          Array of knowledge base item IDs.
         </ResponseField>
         <ResponseField name="call_config" type="object">
           Call configuration settings.

--- a/api-v1/get/vectors-id.mdx
+++ b/api-v1/get/vectors-id.mdx
@@ -1,7 +1,7 @@
 ---
-title: "List Knowledge Base Details"
+title: "List Knowledge Base Item Details"
 api: "GET https://api.bland.ai/v1/knowledgebases/{vector_id}"
-description: "View the details for a specific knowledge base."
+description: "View the details for a specific knowledge base item."
 ---
 
 ### Headers
@@ -11,27 +11,27 @@ description: "View the details for a specific knowledge base."
 </ParamField>
 
 <ParamField header="include-text" type="boolean" default="false">
-    Include the full text of the documents stored in the knowledge base. This can be useful for debugging, but may return large amounts of data.
+    Include the full text of the documents stored in the knowledge base item. This can be useful for debugging, but may return large amounts of data.
 </ParamField>
 
 ### Path Parameters
 
 <ParamField path="vector_id" type="string" required>
-    The `vector_id` of the knowledge base to view.
+    The `vector_id` of the knowledge base item to view.
 </ParamField>
 
 ### Response
 
 <ResponseField name="vector_id" type="string">
-    The unique identifier for the knowledge base.
+    The unique identifier for the knowledge base item.
 </ResponseField>
 
 <ResponseField name="name" type="string">
-    The name of the knowledge base.
+    The name of the knowledge base item.
 </ResponseField>
 
 <ResponseField name="description" type="string">
-    A description of the knowledge base.
+    A description of the knowledge base item.
 </ResponseField>
 
 

--- a/api-v1/get/vectors.mdx
+++ b/api-v1/get/vectors.mdx
@@ -1,7 +1,7 @@
 ---
-title: "List Knowledge Bases"
+title: "List Knowledge Base Items"
 api: "GET https://api.bland.ai/v1/knowledgebases"
-description: "List all knowledge bases in your account."
+description: "List all knowledge base items in your account."
 ---
 
 ### Headers
@@ -11,24 +11,24 @@ description: "List all knowledge bases in your account."
 </ParamField>
 
 <ParamField header="include-text" type="boolean" default="false">
-    Include the full text of the documents stored in the knowledge base. This can be useful for debugging, but may return large amounts of data.
+    Include the full text of the documents stored in the knowledge base item. This can be useful for debugging, but may return large amounts of data.
 </ParamField>
 
 ### Response
 
 <ResponseField name="vectors" type="array">
-    An array of objects, for each knowledge base in your account.
+    An array of objects, for each knowledge base item in your account.
 
     <ResponseField name="vectors[].vector_id" type="string">
-        The unique identifier for the knowledge base.
+        The unique identifier for the knowledge base item.
     </ResponseField>
 
     <ResponseField name="vectors[].name" type="string">
-        The name of the knowledge base.
+        The name of the knowledge base item.
     </ResponseField>
 
     <ResponseField name="vectors[].description" type="string">
-        A description of the knowledge base.
+        A description of the knowledge base item.
     </ResponseField>
 </ResponseField>
 

--- a/api-v1/patch/personas-id.mdx
+++ b/api-v1/patch/personas-id.mdx
@@ -101,7 +101,7 @@ description: "Update an existing persona configuration."
 </ParamField>
 
 <ParamField body="kb_ids" type="array">
-  Updated array of knowledge base IDs to connect to the persona.
+  Updated array of knowledge base item IDs to connect to the persona.
 </ParamField>
 
 ### Response

--- a/api-v1/patch/vectors-id.mdx
+++ b/api-v1/patch/vectors-id.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Update Knowledge Base" 
+title: "Update Knowledge Base Item" 
 api: "PATCH https://api.bland.ai/v1/knowledgebases/{vector_id}"
-description: "Update a knowledge base."
+description: "Update a knowledge base item."
 ---
 
-Usage: Pass the `vector_id` into your agent's `tools` to enable the agent to use the knowledge base.
+Usage: Pass the `vector_id` into your agent's `tools` to enable the agent to use the knowledge base item.
 ```json
 "tools": [
     "KB-55e64dae-1585-4632-ae97-c909c288c6bc"
@@ -20,17 +20,17 @@ Usage: Pass the `vector_id` into your agent's `tools` to enable the agent to use
 ### Path Parameters
 
 <ParamField path="vector_id" type="string" required>
-    The `vector_id` of the knowledge base to update.
+    The `vector_id` of the knowledge base item to update.
 </ParamField>
 
 ### Body
 
 <ParamField body="name" type="string" required>
-  The name of the knowledge base. Make this a clear name that describes the contents of the store.
+  The name of the knowledge base item. Make this a clear name that describes the contents of the store.
 </ParamField>
 
 <ParamField body="description" type="string" required>
-    A description of the knowledge base. This can be a longer description of the contents of the knowledge base, or what terms to use to search for vectors in the knowledge base.
+    A description of the knowledge base item. This can be a longer description of the contents of the knowledge base item, or what terms to use to search for vectors in the knowledge base item.
 
     This is visible to the AI, so making it descriptive can help the AI understand when to use it or not.
 </ParamField>
@@ -42,7 +42,7 @@ Usage: Pass the `vector_id` into your agent's `tools` to enable the agent to use
 ### Response
 
 <ResponseField name="vector_id" type="string">
-  The unique identifier for the knowledge base.
+  The unique identifier for the knowledge base item.
 
   Will start with "KB-".
 </ResponseField>

--- a/api-v1/post/calls.mdx
+++ b/api-v1/post/calls.mdx
@@ -355,7 +355,7 @@ Send an AI phone call with a custom objective and actions. This endpoint can be 
 ### Knowledge Parameters
 
 <ParamField body="tools" type="array">
-  Add custom tools and knowledge bases to your call for your agent to call upon.
+  Add custom tools and knowledge base items to your call for your agent to call upon.
 
   Example:
 

--- a/api-v1/post/knowledge-chat.mdx
+++ b/api-v1/post/knowledge-chat.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Chat with Knowledge Base"
+title: "Chat with Knowledge Base Item"
 api: "POST https://api.bland.ai/v1/knowledge/chat"
-description: "Performs a conversational query against knowledge bases with context."
+description: "Performs a conversational query against knowledge base items with context."
 ---
 
-Query a knowledge base using natural language and receive contextual responses. This endpoint supports both direct queries and conversational context through message history.
+Query a knowledge base item using natural language and receive contextual responses. This endpoint supports both direct queries and conversational context through message history.
 
 ### Headers
 
@@ -31,7 +31,7 @@ Query a knowledge base using natural language and receive contextual responses. 
 </ParamField>
 
 <ParamField body="knowledge_base_id" type="string" required>
-  The ID of the knowledge base to query against.
+  The ID of the knowledge base item to query against.
 </ParamField>
 
 ### Response
@@ -40,7 +40,7 @@ Query a knowledge base using natural language and receive contextual responses. 
   Chat response with contextual information.
 
   <ResponseField name="data.response" type="string">
-    The AI-generated response based on the knowledge base content.
+    The AI-generated response based on the knowledge base item content.
   </ResponseField>
 
   <ResponseField name="data.context" type="string">

--- a/api-v1/post/knowledge-crawl.mdx
+++ b/api-v1/post/knowledge-crawl.mdx
@@ -4,7 +4,7 @@ api: "POST https://api.bland.ai/v1/knowledge/crawl"
 description: "Discovers URLs from a website's sitemap for web scraping."
 ---
 
-Analyzes a website to discover available URLs from its sitemap. This is useful for finding all the pages available on a website before creating a web scraping knowledge base.
+Analyzes a website to discover available URLs from its sitemap. This is useful for finding all the pages available on a website before creating a web scraping knowledge base item.
 
 ### Headers
 

--- a/api-v1/post/knowledge-improve.mdx
+++ b/api-v1/post/knowledge-improve.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Create Suggestion"
 api: "POST https://api.bland.ai/v1/knowledge/{knowledge_base_id}/improve"
-description: "Creates a new suggestion (Q&A pair) for a knowledge base."
+description: "Creates a new suggestion (Q&A pair) for a knowledge base item."
 ---
 
-Add a question and answer pair to improve a knowledge base. These suggestions help enhance the knowledge base's ability to respond to specific queries that may not be well-covered by the existing content.
+Add a question and answer pair to improve a knowledge base item. These suggestions help enhance the knowledge base item's ability to respond to specific queries that may not be well-covered by the existing content.
 
 ### Headers
 
@@ -19,7 +19,7 @@ Add a question and answer pair to improve a knowledge base. These suggestions he
 ### Path Parameters
 
 <ParamField path="knowledge_base_id" type="string" required>
-  The unique identifier of the knowledge base to add the suggestion to.
+  The unique identifier of the knowledge base item to add the suggestion to.
 </ParamField>
 
 ### Body Parameters
@@ -53,7 +53,7 @@ Add a question and answer pair to improve a knowledge base. These suggestions he
     </ResponseField>
 
     <ResponseField name="data.suggestion.knowledge_base_id" type="string">
-      The ID of the knowledge base this suggestion belongs to.
+      The ID of the knowledge base item this suggestion belongs to.
     </ResponseField>
 
     <ResponseField name="data.suggestion.question" type="string">

--- a/api-v1/post/knowledge-learn-file.mdx
+++ b/api-v1/post/knowledge-learn-file.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Upload File"
 api: "POST https://api.bland.ai/v1/knowledge/learn"
-description: "Creates a new knowledge base by uploading a file."
+description: "Creates a new knowledge base item by uploading a file."
 ---
 
-Upload a file to create a knowledge base that can be used to provide contextual information to your AI agents. Supported file formats include PDF, Word documents, text files, and more.
+Upload a file to create a knowledge base item that can be used to provide contextual information to your AI agents. Supported file formats include PDF, Word documents, text files, and more.
 
 ### Headers
 
@@ -27,28 +27,28 @@ Upload a file to create a knowledge base that can be used to provide contextual 
 </ParamField>
 
 <ParamField body="description" type="string">
-  Optional description of the knowledge base content.
+  Optional description of the knowledge base item content.
 </ParamField>
 
 <ParamField body="file" type="file" required>
-  The file to upload and process into a knowledge base.
+  The file to upload and process into a knowledge base item.
 </ParamField>
 
 ### Response
 
 <ResponseField name="data" type="object">
-  The created knowledge base object.
+  The created knowledge base item object.
 
   <ResponseField name="data.id" type="string">
-    Unique identifier for the knowledge base.
+    Unique identifier for the knowledge base item.
   </ResponseField>
 
   <ResponseField name="data.name" type="string">
-    Name of the knowledge base.
+    Name of the knowledge base item.
   </ResponseField>
 
   <ResponseField name="data.description" type="string">
-    Description of the knowledge base (if provided).
+    Description of the knowledge base item (if provided).
   </ResponseField>
 
   <ResponseField name="data.status" type="string">
@@ -56,7 +56,7 @@ Upload a file to create a knowledge base that can be used to provide contextual 
   </ResponseField>
 
   <ResponseField name="data.type" type="string">
-    Will be `"FILE"` for file-based knowledge bases.
+    Will be `"FILE"` for file-based knowledge base items.
   </ResponseField>
 
   <ResponseField name="data.created_at" type="string">

--- a/api-v1/post/knowledge-learn-text.mdx
+++ b/api-v1/post/knowledge-learn-text.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Upload Text"
 api: "POST https://api.bland.ai/v1/knowledge/learn"
-description: "Creates a new knowledge base from direct text input."
+description: "Creates a new knowledge base item from direct text input."
 ---
 
-Create a knowledge base by providing text content directly in the request. This is ideal for when you have structured text content that you want to make searchable for your AI agents.
+Create a knowledge base item by providing text content directly in the request. This is ideal for when you have structured text content that you want to make searchable for your AI agents.
 
 ### Headers
 
@@ -13,42 +13,42 @@ Create a knowledge base by providing text content directly in the request. This 
 </ParamField>
 
 <ParamField header="content-type" type="string" required>
-  Must be `application/json` for text-based knowledge bases.
+  Must be `application/json` for text-based knowledge base items.
 </ParamField>
 
 ### Body Parameters
 
 <ParamField body="type" type="string" required default="text">
-  Must be `"text"` for text-based knowledge bases.
+  Must be `"text"` for text-based knowledge base items.
 </ParamField>
 
 <ParamField body="name" type="string" required>
-  Name for the knowledge base.
+  Name for the knowledge base item.
 </ParamField>
 
 <ParamField body="description" type="string">
-  Optional description of the knowledge base content.
+  Optional description of the knowledge base item content.
 </ParamField>
 
 <ParamField body="text" type="string" required>
-  Text content to be stored in the knowledge base (maximum 1MB).
+  Text content to be stored in the knowledge base item (maximum 1MB).
 </ParamField>
 
 ### Response
 
 <ResponseField name="data" type="object">
-  The created knowledge base object.
+  The created knowledge base item object.
 
   <ResponseField name="data.id" type="string">
-    Unique identifier for the knowledge base.
+    Unique identifier for the knowledge base item.
   </ResponseField>
 
   <ResponseField name="data.name" type="string">
-    Name of the knowledge base.
+    Name of the knowledge base item.
   </ResponseField>
 
   <ResponseField name="data.description" type="string">
-    Description of the knowledge base (if provided).
+    Description of the knowledge base item (if provided).
   </ResponseField>
 
   <ResponseField name="data.status" type="string">
@@ -56,7 +56,7 @@ Create a knowledge base by providing text content directly in the request. This 
   </ResponseField>
 
   <ResponseField name="data.type" type="string">
-    Will be `"TEXT"` for text-based knowledge bases.
+    Will be `"TEXT"` for text-based knowledge base items.
   </ResponseField>
 
   <ResponseField name="data.created_at" type="string">

--- a/api-v1/post/knowledge-learn-web.mdx
+++ b/api-v1/post/knowledge-learn-web.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Scrape Websites"
 api: "POST https://api.bland.ai/v1/knowledge/learn"
-description: "Creates a new knowledge base by scraping content from web URLs."
+description: "Creates a new knowledge base item by scraping content from web URLs."
 ---
 
-Create a knowledge base by scraping content from one or more web URLs. This is perfect for creating knowledge bases from documentation sites, blog posts, or other web-based content.
+Create a knowledge base item by scraping content from one or more web URLs. This is perfect for creating knowledge base items from documentation sites, blog posts, or other web-based content.
 
 ### Headers
 
@@ -13,21 +13,21 @@ Create a knowledge base by scraping content from one or more web URLs. This is p
 </ParamField>
 
 <ParamField header="content-type" type="string" required>
-  Must be `application/json` for web scraping knowledge bases.
+  Must be `application/json` for web scraping knowledge base items.
 </ParamField>
 
 ### Body Parameters
 
 <ParamField body="type" type="string" required default="web">
-  Must be `"web"` for web scraping knowledge bases.
+  Must be `"web"` for web scraping knowledge base items.
 </ParamField>
 
 <ParamField body="name" type="string" required>
-  Name for the knowledge base.
+  Name for the knowledge base item.
 </ParamField>
 
 <ParamField body="description" type="string">
-  Optional description of the knowledge base content.
+  Optional description of the knowledge base item content.
 </ParamField>
 
 <ParamField body="urls" type="string[]" required>
@@ -37,18 +37,18 @@ Create a knowledge base by scraping content from one or more web URLs. This is p
 ### Response
 
 <ResponseField name="data" type="object">
-  The created knowledge base object.
+  The created knowledge base item object.
 
   <ResponseField name="data.id" type="string">
-    Unique identifier for the knowledge base.
+    Unique identifier for the knowledge base item.
   </ResponseField>
 
   <ResponseField name="data.name" type="string">
-    Name of the knowledge base.
+    Name of the knowledge base item.
   </ResponseField>
 
   <ResponseField name="data.description" type="string">
-    Description of the knowledge base (if provided).
+    Description of the knowledge base item (if provided).
   </ResponseField>
 
   <ResponseField name="data.status" type="string">
@@ -56,7 +56,7 @@ Create a knowledge base by scraping content from one or more web URLs. This is p
   </ResponseField>
 
   <ResponseField name="data.type" type="string">
-    Will be `"WEB_SCRAPE"` for web scraping knowledge bases.
+    Will be `"WEB_SCRAPE"` for web scraping knowledge base items.
   </ResponseField>
 
   <ResponseField name="data.source_urls" type="string">

--- a/api-v1/post/personas.mdx
+++ b/api-v1/post/personas.mdx
@@ -95,7 +95,7 @@ description: "Create a new persona."
 </ParamField>
 
 <ParamField body="kb_ids" type="array">
-  Array of knowledge base IDs to connect to the persona.
+  Array of knowledge base item IDs to connect to the persona.
 </ParamField>
 
 ### Response

--- a/api-v1/post/update_pathways.mdx
+++ b/api-v1/post/update_pathways.mdx
@@ -200,7 +200,7 @@ description: "Update a conversational pathway's fields - including name, descrip
       - `transferNumber`
         - If the node is a transfer node, this is the number to which the call will be transferred.
       - `kb`
-        - If the node is a knowledge base node, this is the knowledge base that will be used.
+        - If the node is a knowledge base node, this is the knowledge base item that will be used.
       - `pathwayExamples`
         - The fine-tuning examples for the agent at this node for the pathways chosen
       - `conditionExamples`

--- a/api-v1/post/upload-media.mdx
+++ b/api-v1/post/upload-media.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Upload Media'
 api: 'POST  https://api.bland.ai/v1/knowledgebases/upload-media'
-description: 'Upload a media file as a new knowledge base'
+description: 'Upload a media file as a new knowledge base item'
 contentType: 'multipart/form-data'
 ---
 

--- a/api-v1/post/upload-text.mdx
+++ b/api-v1/post/upload-text.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Upload Text'
 api: 'POST  https://api.bland.ai/v1/knowledgebases/upload'
-description: 'Upload a text file as a new knowledge base'
+description: 'Upload a text file as a new knowledge base item'
 contentType: 'multipart/form-data'
 ---
 

--- a/api-v1/post/vectors.mdx
+++ b/api-v1/post/vectors.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Create a Knowledge Base" 
+title: "Create a Knowledge Base Item" 
 api: "POST https://api.bland.ai/v1/knowledgebases"
-description: "Create a new knowledge base."
+description: "Create a new knowledge base item."
 ---
 
 Usage: Pass the `vector_id` into your agent's `tools` to enable the agent to use the vector store.
@@ -20,11 +20,11 @@ Usage: Pass the `vector_id` into your agent's `tools` to enable the agent to use
 ### Body
 
 <ParamField body="name" type="string" required>
-  The name of the knowledge base. Make this a clear name that describes the contents of the store.
+  The name of the knowledge base item. Make this a clear name that describes the contents of the store.
 </ParamField>
 
 <ParamField body="description" type="string" required>
-  A description of the knowledge base. This can be a longer description of the contents of the store, or what terms to use to search for vectors in the store.
+  A description of the knowledge base item. This can be a longer description of the contents of the store, or what terms to use to search for vectors in the store.
 
   This is visible to the AI, so making it descriptive can help the AI understand when to use it or not.
 </ParamField>
@@ -36,7 +36,7 @@ Usage: Pass the `vector_id` into your agent's `tools` to enable the agent to use
 ### Response
 
 <ResponseField name="vector_id" type="string">
-  The unique identifier for the knowledge base.
+  The unique identifier for the knowledge base item.
 
   Will start with "KB-".
 </ResponseField>

--- a/api-v1/put/knowledge-id.mdx
+++ b/api-v1/put/knowledge-id.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Update Knowledge Base"
+title: "Update Knowledge Base Item"
 api: "PUT https://api.bland.ai/v1/knowledge/{knowledge_base_id}"
-description: "Updates a knowledge base's name and/or description."
+description: "Updates a knowledge base item's name and/or description."
 ---
 
-Updates the metadata (name and description) of an existing knowledge base. This endpoint does not modify the content of the knowledge base, only its descriptive information.
+Updates the metadata (name and description) of an existing knowledge base item. This endpoint does not modify the content of the knowledge base item, only its descriptive information.
 
 ### Headers
 
@@ -19,34 +19,34 @@ Updates the metadata (name and description) of an existing knowledge base. This 
 ### Path Parameters
 
 <ParamField path="knowledge_base_id" type="string" required>
-  The unique identifier of the knowledge base to update.
+  The unique identifier of the knowledge base item to update.
 </ParamField>
 
 ### Body Parameters
 
 <ParamField body="name" type="string">
-  New name for the knowledge base. If not provided, the current name is retained.
+  New name for the knowledge base item. If not provided, the current name is retained.
 </ParamField>
 
 <ParamField body="description" type="string">
-  New description for the knowledge base. Pass `null` to remove the description entirely.
+  New description for the knowledge base item. Pass `null` to remove the description entirely.
 </ParamField>
 
 ### Response
 
 <ResponseField name="data" type="object">
-  The updated knowledge base object.
+  The updated knowledge base item object.
 
   <ResponseField name="data.id" type="string">
-    Unique identifier for the knowledge base.
+    Unique identifier for the knowledge base item.
   </ResponseField>
 
   <ResponseField name="data.name" type="string">
-    Updated name of the knowledge base.
+    Updated name of the knowledge base item.
   </ResponseField>
 
   <ResponseField name="data.description" type="string">
-    Updated description of the knowledge base.
+    Updated description of the knowledge base item.
   </ResponseField>
 
   <ResponseField name="data.status" type="string">
@@ -54,7 +54,7 @@ Updates the metadata (name and description) of an existing knowledge base. This 
   </ResponseField>
 
   <ResponseField name="data.type" type="string">
-    Type of knowledge base: `"FILE"`, `"WEB_SCRAPE"`, or `"TEXT"`.
+    Type of knowledge base item: `"FILE"`, `"WEB_SCRAPE"`, or `"TEXT"`.
   </ResponseField>
 
   <ResponseField name="data.source_urls" type="string">
@@ -78,7 +78,7 @@ Updates the metadata (name and description) of an existing knowledge base. This 
   </ResponseField>
 
   <ResponseField name="data.file" type="object">
-    File information for file-type knowledge bases.
+    File information for file-type knowledge base items.
 
     <ResponseField name="data.file.file_name" type="string">
       Original filename.

--- a/llms.txt
+++ b/llms.txt
@@ -185,25 +185,25 @@ Generate speech from text, manage Bland TTS voices, and clone custom voices. The
 
 ## API Reference: Knowledge Bases
 
-- [Upload File](https://docs.bland.ai/api-v1/post/knowledge-learn-file.md): Create a new knowledge base by uploading a file.
-- [Upload Text](https://docs.bland.ai/api-v1/post/knowledge-learn-text.md): Create a new knowledge base from direct text input.
-- [Scrape Websites](https://docs.bland.ai/api-v1/post/knowledge-learn-web.md): Create a new knowledge base by scraping content from web URLs.
-- [List Knowledge Bases](https://docs.bland.ai/api-v1/get/knowledge.md): Retrieve a paginated list of knowledge bases for your organization.
-- [Get Knowledge Base](https://docs.bland.ai/api-v1/get/knowledge-id.md): Retrieve a specific knowledge base by ID.
-- [Update Knowledge Base](https://docs.bland.ai/api-v1/put/knowledge-id.md): Update a knowledge base's name and/or description.
-- [Delete Knowledge Base](https://docs.bland.ai/api-v1/delete/knowledge-id.md): Delete a knowledge base.
+- [Upload File](https://docs.bland.ai/api-v1/post/knowledge-learn-file.md): Create a new knowledge base item by uploading a file.
+- [Upload Text](https://docs.bland.ai/api-v1/post/knowledge-learn-text.md): Create a new knowledge base item from direct text input.
+- [Scrape Websites](https://docs.bland.ai/api-v1/post/knowledge-learn-web.md): Create a new knowledge base item by scraping content from web URLs.
+- [List Knowledge Base Items](https://docs.bland.ai/api-v1/get/knowledge.md): Retrieve a paginated list of knowledge base items for your organization.
+- [Get Knowledge Base Item](https://docs.bland.ai/api-v1/get/knowledge-id.md): Retrieve a specific knowledge base item by ID.
+- [Update Knowledge Base Item](https://docs.bland.ai/api-v1/put/knowledge-id.md): Update a knowledge base item's name and/or description.
+- [Delete Knowledge Base Item](https://docs.bland.ai/api-v1/delete/knowledge-id.md): Delete a knowledge base item.
 - [Discover Sitemap URLs](https://docs.bland.ai/api-v1/post/knowledge-crawl.md): Discover URLs from a website's sitemap for web scraping.
-- [Chat with Knowledge Base](https://docs.bland.ai/api-v1/post/knowledge-chat.md): Perform a conversational query against knowledge bases with context.
+- [Chat with Knowledge Base Item](https://docs.bland.ai/api-v1/post/knowledge-chat.md): Perform a conversational query against knowledge base items with context.
 
 ### Vector Knowledge Bases (Deprecated)
 
-- [Create Knowledge Base](https://docs.bland.ai/api-v1/post/vectors.md): Create a new knowledge base.
-- [Upload Media](https://docs.bland.ai/api-v1/post/upload-media.md): Upload a media file as a new knowledge base.
-- [Upload Text](https://docs.bland.ai/api-v1/post/upload-text.md): Upload a text file as a new knowledge base.
-- [Update Knowledge Base](https://docs.bland.ai/api-v1/patch/vectors-id.md): Update a knowledge base.
-- [List Knowledge Bases](https://docs.bland.ai/api-v1/get/vectors.md): List all knowledge bases in your account.
-- [Get Knowledge Base Details](https://docs.bland.ai/api-v1/get/vectors-id.md): View the details for a specific knowledge base.
-- [Delete Knowledge Base](https://docs.bland.ai/api-v1/delete/vectors-id.md): Remove a knowledge base from your account.
+- [Create Knowledge Base Item](https://docs.bland.ai/api-v1/post/vectors.md): Create a new knowledge base item.
+- [Upload Media](https://docs.bland.ai/api-v1/post/upload-media.md): Upload a media file as a new knowledge base item.
+- [Upload Text](https://docs.bland.ai/api-v1/post/upload-text.md): Upload a text file as a new knowledge base item.
+- [Update Knowledge Base Item](https://docs.bland.ai/api-v1/patch/vectors-id.md): Update a knowledge base item.
+- [List Knowledge Base Items](https://docs.bland.ai/api-v1/get/vectors.md): List all knowledge base items in your account.
+- [Get Knowledge Base Item Details](https://docs.bland.ai/api-v1/get/vectors-id.md): View the details for a specific knowledge base item.
+- [Delete Knowledge Base Item](https://docs.bland.ai/api-v1/delete/vectors-id.md): Remove a knowledge base item from your account.
 
 ## API Reference: Numbers
 

--- a/sdks/cli.mdx
+++ b/sdks/cli.mdx
@@ -129,7 +129,7 @@ bland call list
   </Accordion>
 
   <Accordion title="Knowledge Bases">
-    Create and manage knowledge bases, including populating them via web scraping.
+    Create and manage knowledge base items, including populating them via web scraping.
 
     ```bash
     bland knowledge list

--- a/tutorials/norm.mdx
+++ b/tutorials/norm.mdx
@@ -49,7 +49,7 @@ Norm works the way an experienced Bland engineer would: it inspects the live sta
 
 ### Build and edit agents
 
-Norm can create a new pathway from a description, edit an existing one, or wire up a new persona, including its voice, language, knowledge bases, and call configuration.
+Norm can create a new pathway from a description, edit an existing one, or wire up a new persona, including its voice, language, knowledge base items, and call configuration.
 
 Common requests:
 

--- a/tutorials/personas.mdx
+++ b/tutorials/personas.mdx
@@ -91,14 +91,14 @@ Configure your persona's conversational behavior and routing logic.
 
 ### Knowledge Integration
 
-Connect your persona to knowledge bases for intelligent information retrieval.
+Connect your persona to knowledge base items for intelligent information retrieval.
 
 <img style={{ borderRadius: "0.5rem" }} src="/tutorials/tutorials-assets/personas/persona_knowledge.jpeg" />
 
 **Knowledge Features:**
-- **Connected Knowledge Bases**: Toggle switches to enable/disable specific knowledge bases (e.g., "Bland Documentation Knowledge Base")
-- **Add More**: "Connect from library" dropdown to search and add knowledge bases from your library with "+ Add" buttons
-- **Manage Knowledge Bases**: Link to knowledge base management
+- **Connected Knowledge Base Items**: Toggle switches to enable/disable specific knowledge base items (e.g., "Bland Documentation Knowledge Base")
+- **Add More**: "Connect from library" dropdown to search and add knowledge base items from your library with "+ Add" buttons
+- **Manage Knowledge Base Items**: Link to knowledge base management
 - **Continuous Learning** (Coming Soon):
   - Question & Answer Improvements
   - Conversational Memory


### PR DESCRIPTION
## What

Renames docs references where **Knowledge Base**/**Knowledge Bases** is used as an individual source or KB item to **knowledge base item(s)**, preserving the original casing. Applies the semantic rule: item-sense → rename; general-concept/feature → leave.

## Scope

31 files changed. Item-sense renames land in the knowledge/vectors CRUD API reference pages, persona `knowledge base IDs`, and clear item references in prose (`tutorials/personas.mdx`, `tutorials/norm.mdx`, `sdks/cli.mdx`, `api-v1/post/calls.mdx`). `llms.txt` titles/descriptions were synced to match the renamed page titles.

## Deliberately left unchanged

- **Pathway "Knowledge Base" node** — node-type list entries, `"type": "Knowledge Base"` literal values, code-block titles, and all of `tutorials/pathways.mdx` (the node is a pathway feature, not a source item).
- **Nav/section names** — `docs.json` nav groups, `llms.txt` section headers, the `sdks/cli` accordion title.
- **Feature-area lists and adjectival uses** — e.g. "knowledge base tool calls", audit "knowledge base edits", the CLI feature list in `bland-tts.mdx`.
- **Proper names** — e.g. "Bland Documentation Knowledge Base".
- **Literal API values** — node-type strings, enum values (`"FILE"`/`"TEXT"`/`"WEB_SCRAPE"`), and example error-message bodies.
- **`changelog/*`** — historical, untouched.

## Verification

- `mint broken-links`: the 6 reported broken links are all pre-existing, in files not touched by this PR. No new broken links.
- No path, navigation, or new-page changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)