### PR TITLE
CUS-1122: Additional KB Endpoints

### DIFF
--- a/api-v1/get/knowledge-id-content.mdx
+++ b/api-v1/get/knowledge-id-content.mdx
@@ -1,0 +1,120 @@
+---
+title: "Get Knowledge Base Content"
+api: "GET https://api.bland.ai/v1/knowledge/{knowledge_base_id}/content"
+description: "Fetch a presigned URL to the current or a specific version's content."
+---
+
+## Overview
+
+Returns a short-lived presigned URL you can download to inspect what a knowledge base version contains. Defaults to the current version; pass `version_id` to fetch an earlier one from [List Versions](/api-v1/get/knowledge-id-versions).
+
+Response shape varies by KB `type`. See the field descriptions and the example variants below.
+
+## Headers
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication.
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="knowledge_base_id" type="string" required>
+  The unique identifier of the knowledge base.
+</ParamField>
+
+## Query Parameters
+
+<ParamField query="version_id" type="string">
+  A specific version to fetch. Defaults to the current version.
+</ParamField>
+
+## Response
+
+<ResponseField name="data" type="object">
+  <Expandable title="Content fields">
+    <ResponseField name="content_url" type="string">
+      Presigned URL to the version's content, valid for 30 minutes. For `PDF` and `DOCX` this points to the extracted markdown; for `TEXT`, `CSV`, and other text formats it points to the source file. Empty string for `WEB_SCRAPE` (URLs live in `source_urls` instead).
+    </ResponseField>
+    <ResponseField name="source_url" type="string">
+      Presigned URL to the original file for display, valid for 30 minutes. Present only for `PDF` and `DOCX` sources.
+    </ResponseField>
+    <ResponseField name="version_id" type="string">
+      The version this response describes.
+    </ResponseField>
+    <ResponseField name="file_name" type="string">
+      Filename of the version's source. Absent for `WEB_SCRAPE`.
+    </ResponseField>
+    <ResponseField name="file_size" type="number">
+      Size in bytes. Absent for `WEB_SCRAPE`.
+    </ResponseField>
+    <ResponseField name="file_type" type="string">
+      MIME type of the returned content. Absent for `WEB_SCRAPE`.
+    </ResponseField>
+    <ResponseField name="is_current" type="boolean">
+      `true` when the returned version is the KB's current version.
+    </ResponseField>
+    <ResponseField name="type" type="string">
+      Knowledge base type: `"FILE"`, `"TEXT"`, or `"WEB_SCRAPE"`.
+    </ResponseField>
+    <ResponseField name="name" type="string">
+      Knowledge base name.
+    </ResponseField>
+    <ResponseField name="source_urls" type="string[]">
+      Present only for `WEB_SCRAPE`. The URLs backing this version.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="errors" type="null | array">
+  `null` on success.
+</ResponseField>
+
+<ResponseExample>
+
+```json Response
+{
+  "data": {
+    "content_url": "https://bland-files-global.s3.us-west-2.amazonaws.com/.../content?X-Amz-...",
+    "version_id": "e6591d44-9318-4b7d-957f-4b27e707238c",
+    "file_name": "patient-corpus.md",
+    "file_size": 48213,
+    "file_type": "text/markdown",
+    "is_current": true,
+    "type": "FILE",
+    "name": "Patient Corpus"
+  },
+  "errors": null
+}
+```
+
+```json Response (WEB_SCRAPE)
+{
+  "data": {
+    "source_urls": [
+      "https://example.com/pricing",
+      "https://example.com/faq"
+    ],
+    "version_id": "ba388d34-ea4b-4526-99fd-4aea80e17177",
+    "is_current": true,
+    "type": "WEB_SCRAPE",
+    "name": "Marketing Site",
+    "content_url": ""
+  },
+  "errors": null
+}
+```
+
+```json Not Found
+{
+  "data": null,
+  "errors": [
+    { "error": "KB_ERROR", "message": "Knowledge base not found" }
+  ]
+}
+```
+
+</ResponseExample>
+
+<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
+  Docs for agents: <a href="/llms.txt">llms.txt</a>
+</div>

--- a/api-v1/get/knowledge-id-content.mdx
+++ b/api-v1/get/knowledge-id-content.mdx
@@ -115,6 +115,6 @@ Response shape varies by KB `type`. See the field descriptions and the example v
 
 </ResponseExample>
 
-<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
-  Docs for agents: <a href="/llms.txt">llms.txt</a>
-</div>
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/knowledge-id-versions-version-id.mdx
+++ b/api-v1/get/knowledge-id-versions-version-id.mdx
@@ -1,0 +1,90 @@
+---
+title: "Get Knowledge Base Version"
+api: "GET https://api.bland.ai/v1/knowledge/{knowledge_base_id}/versions/{version_id}"
+description: "Fetch a presigned URL to a specific version's content."
+---
+
+## Overview
+
+Returns a presigned URL to a specific version's editable content, along with its metadata.
+
+Use [Get Content](/api-v1/get/knowledge-id-content) if you also need the original source file (raw PDF or DOCX) alongside the editable content.
+
+## Headers
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication.
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="knowledge_base_id" type="string" required>
+  The unique identifier of the knowledge base.
+</ParamField>
+
+<ParamField path="version_id" type="string" required>
+  The version to fetch. List available versions with [List Versions](/api-v1/get/knowledge-id-versions).
+</ParamField>
+
+## Response
+
+<ResponseField name="data" type="object">
+  <Expandable title="Fields">
+    <ResponseField name="content_url" type="string">
+      Presigned URL to the version's editable content, valid for 30 minutes. For `PDF` and `DOCX` versions this points to the extracted markdown; for other formats it points to the source file directly.
+    </ResponseField>
+    <ResponseField name="version" type="object">
+      Metadata for the requested version.
+      <Expandable title="Version fields">
+        <ResponseField name="id" type="string">
+          Version id, matches the `version_id` path parameter.
+        </ResponseField>
+        <ResponseField name="created_at" type="string">
+          ISO timestamp of when the version was created.
+        </ResponseField>
+        <ResponseField name="file_name" type="string">
+          Filename of the returned file.
+        </ResponseField>
+        <ResponseField name="file_size" type="number">
+          Size in bytes.
+        </ResponseField>
+      </Expandable>
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="errors" type="null | array">
+  `null` on success.
+</ResponseField>
+
+<ResponseExample>
+
+```json Response
+{
+  "data": {
+    "content_url": "https://bland-files-global.s3.us-west-2.amazonaws.com/.../content?X-Amz-...",
+    "version": {
+      "id": "66120b27-a481-4f83-9d05-772097fa9e98",
+      "created_at": "2026-07-28T14:03:11.240Z",
+      "file_name": "patient-corpus.md",
+      "file_size": 47108
+    }
+  },
+  "errors": null
+}
+```
+
+```json Not Found
+{
+  "data": null,
+  "errors": [
+    { "error": "KB_ERROR", "message": "Version not found" }
+  ]
+}
+```
+
+</ResponseExample>
+
+<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
+  Docs for agents: <a href="/llms.txt">llms.txt</a>
+</div>

--- a/api-v1/get/knowledge-id-versions-version-id.mdx
+++ b/api-v1/get/knowledge-id-versions-version-id.mdx
@@ -85,6 +85,6 @@ Use [Get Content](/api-v1/get/knowledge-id-content) if you also need the origina
 
 </ResponseExample>
 
-<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
-  Docs for agents: <a href="/llms.txt">llms.txt</a>
-</div>
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/knowledge-id-versions.mdx
+++ b/api-v1/get/knowledge-id-versions.mdx
@@ -94,6 +94,6 @@ Each version is created automatically when you call [Update Content](/api-v1/pos
 
 </ResponseExample>
 
-<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
-  Docs for agents: <a href="/llms.txt">llms.txt</a>
-</div>
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/knowledge-id-versions.mdx
+++ b/api-v1/get/knowledge-id-versions.mdx
@@ -1,0 +1,99 @@
+---
+title: "List Knowledge Base Versions"
+api: "GET https://api.bland.ai/v1/knowledge/{knowledge_base_id}/versions"
+description: "List every version of a knowledge base."
+---
+
+## Overview
+
+Returns every version that has ever been created for a knowledge base, plus the id of the current version. Useful for auditing changes, showing history in a UI, or picking a target for [Restore Version](/api-v1/post/knowledge-id-versions-version-id-restore).
+
+Each version is created automatically when you call [Update Content](/api-v1/post/knowledge-id-content), [Replace File](/api-v1/post/knowledge-id-replace), [Replace URLs](/api-v1/post/knowledge-id-replace-urls), or [Restore Version](/api-v1/post/knowledge-id-versions-version-id-restore).
+
+## Headers
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication.
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="knowledge_base_id" type="string" required>
+  The unique identifier of the knowledge base.
+</ParamField>
+
+## Response
+
+<ResponseField name="data" type="object">
+  <Expandable title="Fields">
+    <ResponseField name="versions" type="array">
+      All versions of the knowledge base, newest first.
+      <Expandable title="Version fields">
+        <ResponseField name="id" type="string">
+          Unique identifier for the version.
+        </ResponseField>
+        <ResponseField name="created_at" type="string">
+          ISO timestamp of when the version was created.
+        </ResponseField>
+        <ResponseField name="is_current" type="boolean">
+          `true` if this is the KB's current version.
+        </ResponseField>
+        <ResponseField name="file_name" type="string">
+          Filename of the version's source. Absent for `WEB_SCRAPE`.
+        </ResponseField>
+        <ResponseField name="file_size" type="number">
+          Size in bytes. Absent for `WEB_SCRAPE`.
+        </ResponseField>
+      </Expandable>
+    </ResponseField>
+    <ResponseField name="current_version_id" type="string | null">
+      The id of the current version, or `null` if the KB has no versions yet.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="errors" type="null | array">
+  `null` on success.
+</ResponseField>
+
+<ResponseExample>
+
+```json Response
+{
+  "data": {
+    "versions": [
+      {
+        "id": "dffc76b8-f357-45a0-ad7a-0fdae9616622",
+        "created_at": "2026-07-29T21:17:28.896Z",
+        "is_current": true,
+        "file_name": "patient-corpus.md",
+        "file_size": 48213
+      },
+      {
+        "id": "03423283-76d3-4a49-97ed-049f4f089c9d",
+        "created_at": "2026-07-28T14:03:11.240Z",
+        "is_current": false,
+        "file_name": "patient-corpus.md",
+        "file_size": 47108
+      }
+    ],
+    "current_version_id": "dffc76b8-f357-45a0-ad7a-0fdae9616622"
+  },
+  "errors": null
+}
+```
+
+```json Not Found
+{
+  "data": null,
+  "errors": [
+    { "error": "KB_ERROR", "message": "Knowledge base not found" }
+  ]
+}
+```
+
+</ResponseExample>
+
+<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
+  Docs for agents: <a href="/llms.txt">llms.txt</a>
+</div>

--- a/api-v1/get/knowledge.mdx
+++ b/api-v1/get/knowledge.mdx
@@ -26,70 +26,70 @@ Returns all knowledge bases in your organization with pagination support. Use th
 
 <ResponseField name="data" type="object">
   Paginated list of knowledge bases.
+</ResponseField>
 
-  <ResponseField name="data.kbs" type="array">
-    Array of knowledge base objects.
+<ResponseField name="data.kbs" type="array">
+  Array of knowledge base objects.
+</ResponseField>
 
-    <ResponseField name="data.kbs[].id" type="string">
-      Unique identifier for the knowledge base.
-    </ResponseField>
+<ResponseField name="data.kbs[].id" type="string">
+  Unique identifier for the knowledge base.
+</ResponseField>
 
-    <ResponseField name="data.kbs[].name" type="string">
-      Name of the knowledge base.
-    </ResponseField>
+<ResponseField name="data.kbs[].name" type="string">
+  Name of the knowledge base.
+</ResponseField>
 
-    <ResponseField name="data.kbs[].description" type="string">
-      Description of the knowledge base (if provided).
-    </ResponseField>
+<ResponseField name="data.kbs[].description" type="string">
+  Description of the knowledge base (if provided).
+</ResponseField>
 
-    <ResponseField name="data.kbs[].status" type="string">
-      Current status: `"PROCESSING"`, `"COMPLETED"`, `"FAILED"`, or `"DELETED"`.
-    </ResponseField>
+<ResponseField name="data.kbs[].status" type="string">
+  Current status: `"PROCESSING"`, `"COMPLETED"`, `"FAILED"`, or `"DELETED"`.
+</ResponseField>
 
-    <ResponseField name="data.kbs[].type" type="string">
-      Type of knowledge base: `"FILE"`, `"WEB_SCRAPE"`, or `"TEXT"`.
-    </ResponseField>
+<ResponseField name="data.kbs[].type" type="string">
+  Type of knowledge base: `"FILE"`, `"WEB_SCRAPE"`, or `"TEXT"`.
+</ResponseField>
 
-    <ResponseField name="data.kbs[].source_urls" type="string">
-      Source URLs for web scrape type (comma-separated).
-    </ResponseField>
+<ResponseField name="data.kbs[].source_urls" type="string">
+  Source URLs for web scrape type (comma-separated).
+</ResponseField>
 
-    <ResponseField name="data.kbs[].base_url" type="string">
-      Base URL for web scrape type.
-    </ResponseField>
+<ResponseField name="data.kbs[].base_url" type="string">
+  Base URL for web scrape type.
+</ResponseField>
 
-    <ResponseField name="data.kbs[].created_at" type="string">
-      ISO timestamp of creation.
-    </ResponseField>
+<ResponseField name="data.kbs[].created_at" type="string">
+  ISO timestamp of creation.
+</ResponseField>
 
-    <ResponseField name="data.kbs[].updated_at" type="string">
-      ISO timestamp of last update.
-    </ResponseField>
+<ResponseField name="data.kbs[].updated_at" type="string">
+  ISO timestamp of last update.
+</ResponseField>
 
-    <ResponseField name="data.kbs[].error_message" type="string">
-      Error message if status is `"FAILED"`.
-    </ResponseField>
+<ResponseField name="data.kbs[].error_message" type="string">
+  Error message if status is `"FAILED"`.
+</ResponseField>
 
-    <ResponseField name="data.kbs[].file" type="object">
-      File information for file-type knowledge bases.
+<ResponseField name="data.kbs[].file" type="object">
+  File information for file-type knowledge bases.
+</ResponseField>
 
-      <ResponseField name="data.kbs[].file.file_name" type="string">
-        Original filename.
-      </ResponseField>
+<ResponseField name="data.kbs[].file.file_name" type="string">
+  Original filename.
+</ResponseField>
 
-      <ResponseField name="data.kbs[].file.file_size" type="number">
-        File size in bytes.
-      </ResponseField>
+<ResponseField name="data.kbs[].file.file_size" type="number">
+  File size in bytes.
+</ResponseField>
 
-      <ResponseField name="data.kbs[].file.file_type" type="string">
-        MIME type of the file.
-      </ResponseField>
-    </ResponseField>
-  </ResponseField>
+<ResponseField name="data.kbs[].file.file_type" type="string">
+  MIME type of the file.
+</ResponseField>
 
-  <ResponseField name="data.total" type="number">
-    Total number of knowledge bases in the organization.
-  </ResponseField>
+<ResponseField name="data.total" type="number">
+  Total number of knowledge bases in the organization.
 </ResponseField>
 
 <ResponseField name="errors" type="null">
@@ -150,6 +150,6 @@ curl -X GET "https://api.bland.ai/v1/knowledge?page=2&limit=10" \
 
 </ResponseExample>
 
----
-
-Docs for agents: [llms.txt](/llms.txt)
+<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
+  Docs for agents: <a href="/llms.txt">llms.txt</a>
+</div>

--- a/api-v1/get/knowledge.mdx
+++ b/api-v1/get/knowledge.mdx
@@ -26,70 +26,70 @@ Returns all knowledge bases in your organization with pagination support. Use th
 
 <ResponseField name="data" type="object">
   Paginated list of knowledge bases.
-</ResponseField>
 
-<ResponseField name="data.kbs" type="array">
-  Array of knowledge base objects.
-</ResponseField>
+  <ResponseField name="data.kbs" type="array">
+    Array of knowledge base objects.
 
-<ResponseField name="data.kbs[].id" type="string">
-  Unique identifier for the knowledge base.
-</ResponseField>
+    <ResponseField name="data.kbs[].id" type="string">
+      Unique identifier for the knowledge base.
+    </ResponseField>
 
-<ResponseField name="data.kbs[].name" type="string">
-  Name of the knowledge base.
-</ResponseField>
+    <ResponseField name="data.kbs[].name" type="string">
+      Name of the knowledge base.
+    </ResponseField>
 
-<ResponseField name="data.kbs[].description" type="string">
-  Description of the knowledge base (if provided).
-</ResponseField>
+    <ResponseField name="data.kbs[].description" type="string">
+      Description of the knowledge base (if provided).
+    </ResponseField>
 
-<ResponseField name="data.kbs[].status" type="string">
-  Current status: `"PROCESSING"`, `"COMPLETED"`, `"FAILED"`, or `"DELETED"`.
-</ResponseField>
+    <ResponseField name="data.kbs[].status" type="string">
+      Current status: `"PROCESSING"`, `"COMPLETED"`, `"FAILED"`, or `"DELETED"`.
+    </ResponseField>
 
-<ResponseField name="data.kbs[].type" type="string">
-  Type of knowledge base: `"FILE"`, `"WEB_SCRAPE"`, or `"TEXT"`.
-</ResponseField>
+    <ResponseField name="data.kbs[].type" type="string">
+      Type of knowledge base: `"FILE"`, `"WEB_SCRAPE"`, or `"TEXT"`.
+    </ResponseField>
 
-<ResponseField name="data.kbs[].source_urls" type="string">
-  Source URLs for web scrape type (comma-separated).
-</ResponseField>
+    <ResponseField name="data.kbs[].source_urls" type="string">
+      Source URLs for web scrape type (comma-separated).
+    </ResponseField>
 
-<ResponseField name="data.kbs[].base_url" type="string">
-  Base URL for web scrape type.
-</ResponseField>
+    <ResponseField name="data.kbs[].base_url" type="string">
+      Base URL for web scrape type.
+    </ResponseField>
 
-<ResponseField name="data.kbs[].created_at" type="string">
-  ISO timestamp of creation.
-</ResponseField>
+    <ResponseField name="data.kbs[].created_at" type="string">
+      ISO timestamp of creation.
+    </ResponseField>
 
-<ResponseField name="data.kbs[].updated_at" type="string">
-  ISO timestamp of last update.
-</ResponseField>
+    <ResponseField name="data.kbs[].updated_at" type="string">
+      ISO timestamp of last update.
+    </ResponseField>
 
-<ResponseField name="data.kbs[].error_message" type="string">
-  Error message if status is `"FAILED"`.
-</ResponseField>
+    <ResponseField name="data.kbs[].error_message" type="string">
+      Error message if status is `"FAILED"`.
+    </ResponseField>
 
-<ResponseField name="data.kbs[].file" type="object">
-  File information for file-type knowledge bases.
-</ResponseField>
+    <ResponseField name="data.kbs[].file" type="object">
+      File information for file-type knowledge bases.
 
-<ResponseField name="data.kbs[].file.file_name" type="string">
-  Original filename.
-</ResponseField>
+      <ResponseField name="data.kbs[].file.file_name" type="string">
+        Original filename.
+      </ResponseField>
 
-<ResponseField name="data.kbs[].file.file_size" type="number">
-  File size in bytes.
-</ResponseField>
+      <ResponseField name="data.kbs[].file.file_size" type="number">
+        File size in bytes.
+      </ResponseField>
 
-<ResponseField name="data.kbs[].file.file_type" type="string">
-  MIME type of the file.
-</ResponseField>
+      <ResponseField name="data.kbs[].file.file_type" type="string">
+        MIME type of the file.
+      </ResponseField>
+    </ResponseField>
+  </ResponseField>
 
-<ResponseField name="data.total" type="number">
-  Total number of knowledge bases in the organization.
+  <ResponseField name="data.total" type="number">
+    Total number of knowledge bases in the organization.
+  </ResponseField>
 </ResponseField>
 
 <ResponseField name="errors" type="null">
@@ -150,6 +150,6 @@ curl -X GET "https://api.bland.ai/v1/knowledge?page=2&limit=10" \
 
 </ResponseExample>
 
-<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
-  Docs for agents: <a href="/llms.txt">llms.txt</a>
-</div>
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/knowledge-id-content.mdx
+++ b/api-v1/post/knowledge-id-content.mdx
@@ -1,0 +1,106 @@
+---
+title: "Update Knowledge Base Content"
+api: "POST https://api.bland.ai/v1/knowledge/{knowledge_base_id}/content"
+description: "Replace the text content of a knowledge base and create a new version."
+---
+
+## Overview
+
+Replaces the textual content of a knowledge base in place. The `knowledge_base_id` doesn't change, so agents, pathways, and personas referencing the KB keep working. Each call creates a new version; older versions stay retrievable via [List Versions](/api-v1/get/knowledge-id-versions) and [Restore Version](/api-v1/post/knowledge-id-versions-version-id-restore).
+
+For binary uploads (a new PDF or DOCX), use [Replace File](/api-v1/post/knowledge-id-replace). For URL lists on a `WEB_SCRAPE` KB, use [Replace URLs](/api-v1/post/knowledge-id-replace-urls).
+
+## Headers
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication.
+</ParamField>
+
+<ParamField header="content-type" type="string" required>
+  Must be `application/json`.
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="knowledge_base_id" type="string" required>
+  The unique identifier of the knowledge base to update.
+</ParamField>
+
+## Body Parameters
+
+<ParamField body="content" type="string" required>
+  The new content. Non-empty string, maximum 10MB. Interpretation depends on the KB type.
+
+  <Accordion title="By KB type">
+    - **`TEXT`**: plain-text body.
+    - **`FILE`** (PDF or DOCX): new markdown that the agent will read. The original PDF or DOCX source is retained for display via [Get Content](/api-v1/get/knowledge-id-content).
+    - **`FILE`** (CSV, TXT, or other text formats): new file body in its original format.
+    - **`WEB_SCRAPE`**: accepted, but prefer [Replace URLs](/api-v1/post/knowledge-id-replace-urls) to change what gets scraped.
+  </Accordion>
+</ParamField>
+
+## Response
+
+<ResponseField name="data" type="object">
+  <Expandable title="Fields">
+    <ResponseField name="success" type="boolean">
+      `true` on success.
+    </ResponseField>
+    <ResponseField name="version_id" type="string">
+      The id of the newly created version. This becomes the KB's current version.
+    </ResponseField>
+    <ResponseField name="message" type="string">
+      Human-readable confirmation, for example `"Content updated successfully. Re-embedding in progress."`.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="errors" type="null | array">
+  `null` on success.
+</ResponseField>
+
+<ResponseExample>
+
+```json Response
+{
+  "data": {
+    "success": true,
+    "version_id": "e4896c91-7b42-48bd-bfa6-b14b3bb7cb56",
+    "message": "Content updated successfully. Re-embedding in progress."
+  },
+  "errors": null
+}
+```
+
+```json Invalid Content
+{
+  "data": null,
+  "errors": [
+    { "error": "KB_ERROR", "message": "content must be a non-empty string" }
+  ]
+}
+```
+
+```json Content Too Large
+{
+  "data": null,
+  "errors": [
+    { "error": "KB_ERROR", "message": "Content exceeds 10MB limit" }
+  ]
+}
+```
+
+```json Not Found
+{
+  "data": null,
+  "errors": [
+    { "error": "KB_ERROR", "message": "Knowledge base not found" }
+  ]
+}
+```
+
+</ResponseExample>
+
+<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
+  Docs for agents: <a href="/llms.txt">llms.txt</a>
+</div>

--- a/api-v1/post/knowledge-id-content.mdx
+++ b/api-v1/post/knowledge-id-content.mdx
@@ -101,6 +101,6 @@ For binary uploads (a new PDF or DOCX), use [Replace File](/api-v1/post/knowledg
 
 </ResponseExample>
 
-<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
-  Docs for agents: <a href="/llms.txt">llms.txt</a>
-</div>
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/knowledge-id-replace-urls.mdx
+++ b/api-v1/post/knowledge-id-replace-urls.mdx
@@ -109,6 +109,6 @@ If the KB is still indexing the previous replacement, the request returns `409` 
 
 </ResponseExample>
 
-<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
-  Docs for agents: <a href="/llms.txt">llms.txt</a>
-</div>
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/knowledge-id-replace-urls.mdx
+++ b/api-v1/post/knowledge-id-replace-urls.mdx
@@ -1,0 +1,114 @@
+---
+title: "Replace Knowledge Base URLs"
+api: "POST https://api.bland.ai/v1/knowledge/{knowledge_base_id}/replace_urls"
+description: "Replace the list of URLs backing a WEB_SCRAPE knowledge base."
+---
+
+## Overview
+
+Updates the URL list on a `WEB_SCRAPE`-type knowledge base and creates a new version. The `knowledge_base_id` stays the same, so anything referencing the KB keeps working. Older URL sets stay retrievable via [List Versions](/api-v1/get/knowledge-id-versions) and [Restore Version](/api-v1/post/knowledge-id-versions-version-id-restore). For `FILE` KBs use [Replace File](/api-v1/post/knowledge-id-replace); for `TEXT` use [Update Content](/api-v1/post/knowledge-id-content).
+
+## Headers
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication.
+</ParamField>
+
+<ParamField header="content-type" type="string" required>
+  Must be `application/json`.
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="knowledge_base_id" type="string" required>
+  The unique identifier of the knowledge base to replace.
+</ParamField>
+
+## Body Parameters
+
+<ParamField body="urls" type="string[]" required>
+  Non-empty array of absolute URLs to scrape. Each URL is parsed with `new URL(...)` and rejected if invalid. Maximum 100 URLs for standard accounts, 2000 for enterprise accounts.
+</ParamField>
+
+## Concurrency
+
+If the KB is still indexing the previous replacement, the request returns `409` with the message `"Source is still indexing the previous Replace URLs. Wait until it completes."`. Poll [Get Knowledge Base](/api-v1/get/knowledge-id) until `status` returns to `"COMPLETED"` before retrying.
+
+## Response
+
+<ResponseField name="data" type="object">
+  <Expandable title="Fields">
+    <ResponseField name="success" type="boolean">
+      `true` on success.
+    </ResponseField>
+    <ResponseField name="version_id" type="string">
+      The id of the newly created version. This becomes the KB's current version.
+    </ResponseField>
+    <ResponseField name="urls_count" type="number">
+      Number of URLs accepted for this version.
+    </ResponseField>
+    <ResponseField name="message" type="string">
+      Human-readable confirmation, for example `"URLs replaced successfully. Re-scraping and re-embedding in progress."`.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="errors" type="null | array">
+  `null` on success.
+</ResponseField>
+
+<ResponseExample>
+
+```json Response
+{
+  "data": {
+    "success": true,
+    "version_id": "5e69308a-31f3-4f94-bde6-db6602e57be0",
+    "urls_count": 3,
+    "message": "URLs replaced successfully. Re-scraping and re-embedding in progress."
+  },
+  "errors": null
+}
+```
+
+```json Empty URLs
+{
+  "data": null,
+  "errors": [
+    { "error": "KB_ERROR", "message": "urls must be a non-empty array" }
+  ]
+}
+```
+
+```json Invalid URL
+{
+  "data": null,
+  "errors": [
+    { "error": "KB_ERROR", "message": "Invalid URL: not-a-url" }
+  ]
+}
+```
+
+```json Too Many URLs
+{
+  "data": null,
+  "errors": [
+    { "error": "KB_ERROR", "message": "Maximum 100 URLs allowed" }
+  ]
+}
+```
+
+```json Wrong KB Type
+{
+  "data": null,
+  "errors": [
+    { "error": "KB_ERROR", "message": "Knowledge base not found or not a web scraping type" }
+  ]
+}
+```
+
+</ResponseExample>
+
+<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
+  Docs for agents: <a href="/llms.txt">llms.txt</a>
+</div>

--- a/api-v1/post/knowledge-id-replace.mdx
+++ b/api-v1/post/knowledge-id-replace.mdx
@@ -1,0 +1,101 @@
+---
+title: "Replace Knowledge Base File"
+api: "POST https://api.bland.ai/v1/knowledge/{knowledge_base_id}/replace"
+description: "Upload a new file to replace the current source of a FILE knowledge base."
+---
+
+## Overview
+
+Uploads a new source file into an existing `FILE`-type knowledge base and creates a new version. The `knowledge_base_id` stays the same, so anything referencing the KB keeps working. Older versions stay retrievable via [List Versions](/api-v1/get/knowledge-id-versions) and [Restore Version](/api-v1/post/knowledge-id-versions-version-id-restore). For `TEXT` KBs use [Update Content](/api-v1/post/knowledge-id-content); for `WEB_SCRAPE` use [Replace URLs](/api-v1/post/knowledge-id-replace-urls).
+
+## Headers
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication.
+</ParamField>
+
+<ParamField header="content-type" type="string" required>
+  Must be `multipart/form-data`.
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="knowledge_base_id" type="string" required>
+  The unique identifier of the knowledge base to replace.
+</ParamField>
+
+## Body Parameters
+
+<ParamField body="file" type="file" required>
+  A single file part. Maximum size 20MB. The filename and MIME type are read from the multipart part.
+</ParamField>
+
+## Concurrency
+
+The endpoint refuses a second Replace File call while the previous re-embedding is still running, returning `409` with the message `"Source is still indexing the previous Replace File. Wait until it completes."`. Poll [Get Knowledge Base](/api-v1/get/knowledge-id) until `status` returns to `"COMPLETED"` before issuing the next replacement.
+
+## Response
+
+<ResponseField name="data" type="object">
+  <Expandable title="Fields">
+    <ResponseField name="success" type="boolean">
+      `true` on success.
+    </ResponseField>
+    <ResponseField name="version_id" type="string">
+      The id of the newly created version. This becomes the KB's current version.
+    </ResponseField>
+    <ResponseField name="message" type="string">
+      Human-readable confirmation, for example `"File replaced successfully. Re-embedding in progress."`.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="errors" type="null | array">
+  `null` on success.
+</ResponseField>
+
+<ResponseExample>
+
+```json Response
+{
+  "data": {
+    "success": true,
+    "version_id": "f86d29be-c0e2-49c0-bc0a-f0a0d8998e75",
+    "message": "File replaced successfully. Re-embedding in progress."
+  },
+  "errors": null
+}
+```
+
+```json No File
+{
+  "data": null,
+  "errors": [
+    { "error": "NO_FILE", "message": "No file uploaded" }
+  ]
+}
+```
+
+```json Wrong KB Type
+{
+  "data": null,
+  "errors": [
+    { "error": "KB_ERROR", "message": "KB not found or type not supported for replacement" }
+  ]
+}
+```
+
+```json Still Indexing
+{
+  "data": null,
+  "errors": [
+    { "error": "KB_ERROR", "message": "Source is still indexing the previous Replace File. Wait until it completes." }
+  ]
+}
+```
+
+</ResponseExample>
+
+<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
+  Docs for agents: <a href="/llms.txt">llms.txt</a>
+</div>

--- a/api-v1/post/knowledge-id-replace.mdx
+++ b/api-v1/post/knowledge-id-replace.mdx
@@ -96,6 +96,6 @@ The endpoint refuses a second Replace File call while the previous re-embedding 
 
 </ResponseExample>
 
-<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
-  Docs for agents: <a href="/llms.txt">llms.txt</a>
-</div>
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/knowledge-id-versions-version-id-restore.mdx
+++ b/api-v1/post/knowledge-id-versions-version-id-restore.mdx
@@ -70,6 +70,6 @@ The prior current version stays in the version list and can be restored again. U
 
 </ResponseExample>
 
-<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
-  Docs for agents: <a href="/llms.txt">llms.txt</a>
-</div>
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/knowledge-id-versions-version-id-restore.mdx
+++ b/api-v1/post/knowledge-id-versions-version-id-restore.mdx
@@ -1,0 +1,75 @@
+---
+title: "Restore Knowledge Base Version"
+api: "POST https://api.bland.ai/v1/knowledge/{knowledge_base_id}/versions/{version_id}/restore"
+description: "Repoint the current version of a knowledge base at a prior version."
+---
+
+## Overview
+
+Sets the knowledge base's current version to `version_id`. The KB flips to `PROCESSING` while Bland re-embeds against the restored version. The `knowledge_base_id` does not change, so agents and pathways that reference it start reading the restored content as soon as re-embedding completes.
+
+The prior current version stays in the version list and can be restored again. Use [List Versions](/api-v1/get/knowledge-id-versions) to pick a target.
+
+## Headers
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication.
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="knowledge_base_id" type="string" required>
+  The unique identifier of the knowledge base.
+</ParamField>
+
+<ParamField path="version_id" type="string" required>
+  The version to restore. Must be a version of this knowledge base.
+</ParamField>
+
+## Response
+
+<ResponseField name="data" type="object">
+  <Expandable title="Fields">
+    <ResponseField name="success" type="boolean">
+      `true` on success.
+    </ResponseField>
+    <ResponseField name="restored_version_id" type="string">
+      The version now marked current, matches the `version_id` path parameter.
+    </ResponseField>
+    <ResponseField name="message" type="string">
+      Human-readable confirmation, for example `"Version restored successfully. Re-embedding in progress."`.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="errors" type="null | array">
+  `null` on success.
+</ResponseField>
+
+<ResponseExample>
+
+```json Response
+{
+  "data": {
+    "success": true,
+    "restored_version_id": "dbddbf35-ab12-448a-b936-61048caa51f6",
+    "message": "Version restored successfully. Re-embedding in progress."
+  },
+  "errors": null
+}
+```
+
+```json Not Found
+{
+  "data": null,
+  "errors": [
+    { "error": "KB_ERROR", "message": "Version not found" }
+  ]
+}
+```
+
+</ResponseExample>
+
+<div style={{ marginTop: '2.5rem', marginBottom: '2.5rem', fontSize: '0.9em', opacity: 0.75 }}>
+  Docs for agents: <a href="/llms.txt">llms.txt</a>
+</div>

--- a/docs.json
+++ b/docs.json
@@ -271,6 +271,13 @@
                   "api-v1/delete/knowledge-id",
                   "api-v1/post/knowledge-crawl",
                   "api-v1/post/knowledge-chat",
+                  "api-v1/get/knowledge-id-content",
+                  "api-v1/post/knowledge-id-content",
+                  "api-v1/post/knowledge-id-replace",
+                  "api-v1/post/knowledge-id-replace-urls",
+                  "api-v1/get/knowledge-id-versions",
+                  "api-v1/get/knowledge-id-versions-version-id",
+                  "api-v1/post/knowledge-id-versions-version-id-restore",
                   {
                     "group": "Vector Knowledge Bases (Deprecated)",
                     "pages": [

--- a/llms.txt
+++ b/llms.txt
@@ -109,6 +109,8 @@ Bland holds SOC 2 Type II, HIPAA, GDPR, and PCI DSS certifications. Self-hosted 
 - [Get Post Call Webhook](https://docs.bland.ai/api-v1/get/postcall-webhooks-get.md): Get the post call webhook data for a specific call.
 - [Create Post Call Webhook](https://docs.bland.ai/api-v1/post/postcall-webhooks-create.md): Create and send post call webhooks for specified calls.
 - [Resend Post Call Webhook](https://docs.bland.ai/api-v1/post/postcall-webhooks-resend.md): Resend post call webhooks for specified calls.
+- [Get Transcript Stream URL](https://docs.bland.ai/api-v1/post/calls-id-transcript-stream-token.md): Get a short-lived WebSocket URL for a call's live post-transfer transcript stream.
+- [Post-Transfer Transcript Stream (WebSocket)](https://docs.bland.ai/api-v1/post/calls-id-transcript-stream.md): Live transcript of the conversation after a call is transferred to a human.
 
 ## API Reference: Voices & Text to Speech
 
@@ -199,6 +201,18 @@ Generate speech from text, manage Bland TTS voices, and clone custom voices. The
 - [Delete Knowledge Base](https://docs.bland.ai/api-v1/delete/knowledge-id.md): Delete a knowledge base.
 - [Discover Sitemap URLs](https://docs.bland.ai/api-v1/post/knowledge-crawl.md): Discover URLs from a website's sitemap for web scraping.
 - [Chat with Knowledge Base](https://docs.bland.ai/api-v1/post/knowledge-chat.md): Perform a conversational query against knowledge bases with context.
+
+### Content & Versions
+
+Every knowledge base carries a version history. Content updates create a new version under the same `knowledge_base_id`, so bindings on agents, pathways, and personas never need to be rewired.
+
+- [Get Knowledge Base Content](https://docs.bland.ai/api-v1/get/knowledge-id-content.md): Fetch a presigned URL to the current or a specific version's content.
+- [Update Knowledge Base Content](https://docs.bland.ai/api-v1/post/knowledge-id-content.md): Replace the text content of a knowledge base and create a new version.
+- [Replace Knowledge Base File](https://docs.bland.ai/api-v1/post/knowledge-id-replace.md): Upload a new file to replace the current source of a FILE knowledge base.
+- [Replace Knowledge Base URLs](https://docs.bland.ai/api-v1/post/knowledge-id-replace-urls.md): Replace the list of URLs backing a WEB_SCRAPE knowledge base.
+- [List Knowledge Base Versions](https://docs.bland.ai/api-v1/get/knowledge-id-versions.md): List every version of a knowledge base.
+- [Get Knowledge Base Version](https://docs.bland.ai/api-v1/get/knowledge-id-versions-version-id.md): Fetch a presigned URL to a specific version's content.
+- [Restore Knowledge Base Version](https://docs.bland.ai/api-v1/post/knowledge-id-versions-version-id-restore.md): Repoint the current version of a knowledge base at a prior version.
 
 ### Vector Knowledge Bases (Deprecated)
 


### PR DESCRIPTION
Linear: [CUS-1122](https://linear.app/blandai/issue/CUS-1122/create-kb-content-docs)

## Summary

Adds public reference docs for the seven `/v1/knowledge/{knowledge_base_id}/*` versioning and content-mutation endpoints that were already live in the API but undocumented. Motivated by a customer needing to update KB content from CI while keeping the same `knowledge_base_id`.

- `GET  /v1/knowledge/{id}/content`: presigned URL to current or specific version content
- `POST /v1/knowledge/{id}/content`: replace text or markdown content, creates new version
- `POST /v1/knowledge/{id}/replace`: replace file (multipart), creates new version
- `POST /v1/knowledge/{id}/replace_urls`: replace URL list on WEB_SCRAPE, creates new version
- `GET  /v1/knowledge/{id}/versions`: list versions
- `GET  /v1/knowledge/{id}/versions/{version_id}`: get a single version
- `POST /v1/knowledge/{id}/versions/{version_id}/restore`: repoint the current version pointer

Every endpoint was exercised live against api.bland.ai while drafting. Response shapes, error variants, and concurrency 409s were verified on throwaway TEXT, FILE, and WEB_SCRAPE knowledge bases.

## Test plan

- [ ] Mintlify preview renders the 7 new pages without errors
- [ ] Sidebar shows the 7 new pages under Knowledge Bases
- [ ] llms.txt links resolve for each new page