### PR TITLE
CUS-1071 docs: add Custom Code Snippets API reference (v1/snippets)

### DIFF
--- a/api-v1/get/snippets-id.mdx
+++ b/api-v1/get/snippets-id.mdx
@@ -1,0 +1,82 @@
+---
+title: "Get Snippet"
+api: "GET https://api.bland.ai/v1/snippets/get/{snippet_id}"
+description: "Retrieve a snippet's source code, either the latest version or all versions."
+---
+
+### Headers
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication.
+</ParamField>
+
+### Path Parameters
+
+<ParamField path="snippet_id" type="string" required>
+  ID of the snippet to retrieve.
+</ParamField>
+
+### Query Parameters
+
+<ParamField query="all_versions" type="boolean" default="false">
+  Pass `true` to return every version of the snippet, newest first. When set, `data` is an array of snippet objects instead of a single object.
+</ParamField>
+
+### Response
+
+<ResponseField name="data" type="object">
+  The latest version of the snippet. An array of these objects when `all_versions=true`.
+
+  <Expandable title="snippet object">
+    <ResponseField name="snippet_id" type="string">
+      Unique identifier for the snippet.
+    </ResponseField>
+    <ResponseField name="version" type="integer">
+      Version number.
+    </ResponseField>
+    <ResponseField name="created_at" type="string">
+      ISO 8601 timestamp of when this version was created.
+    </ResponseField>
+    <ResponseField name="display_name" type="string">
+      Name of the snippet.
+    </ResponseField>
+    <ResponseField name="content" type="string">
+      The snippet's source code.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="errors" type="null">
+  Error array (null on success).
+</ResponseField>
+
+<ResponseExample>
+```json Response
+{
+  "data": {
+    "snippet_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "version": 2,
+    "created_at": "2026-07-20T10:30:00.000Z",
+    "display_name": "order_lookup",
+    "content": "export default {\n  async fetch(request, env, ctx) {\n    const input = await request.json();\n    return Response.json({ message: `Hi again, ${input.name}` });\n  }\n}"
+  },
+  "errors": null
+}
+```
+
+```json Not Found
+{
+  "data": null,
+  "errors": [
+    {
+      "error": "SCRIPT_GET_FAILED",
+      "message": "Snippet not found"
+    }
+  ]
+}
+```
+</ResponseExample>
+
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/get/snippets-list.mdx
+++ b/api-v1/get/snippets-list.mdx
@@ -1,0 +1,74 @@
+---
+title: "List Snippets"
+api: "GET https://api.bland.ai/v1/snippets/list"
+description: "List your organization's snippets at their latest version."
+---
+
+Returns one entry per snippet, each at its latest version. Use [Get Snippet](/api-v1/get/snippets-id) to retrieve a snippet's source code or version history.
+
+### Headers
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication.
+</ParamField>
+
+### Query Parameters
+
+<ParamField query="take" type="integer" default="10">
+  Number of snippets to return.
+</ParamField>
+
+<ParamField query="skip" type="integer" default="0">
+  Number of snippets to skip, for pagination.
+</ParamField>
+
+### Response
+
+<ResponseField name="data" type="array">
+  Array of snippet objects.
+
+  <Expandable title="snippet object">
+    <ResponseField name="snippet_id" type="string">
+      Unique identifier for the snippet.
+    </ResponseField>
+    <ResponseField name="version" type="integer">
+      Latest version number of the snippet.
+    </ResponseField>
+    <ResponseField name="created_at" type="string">
+      ISO 8601 timestamp of when the latest version was created.
+    </ResponseField>
+    <ResponseField name="display_name" type="string">
+      Name of the snippet.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="errors" type="null">
+  Error array (null on success).
+</ResponseField>
+
+<ResponseExample>
+```json Response
+{
+  "data": [
+    {
+      "snippet_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "version": 2,
+      "created_at": "2026-07-20T10:30:00.000Z",
+      "display_name": "order_lookup"
+    },
+    {
+      "snippet_id": "ffffffff-1111-2222-3333-444444444444",
+      "version": 1,
+      "created_at": "2026-07-18T09:15:00.000Z",
+      "display_name": "calculate_discount"
+    }
+  ],
+  "errors": null
+}
+```
+</ResponseExample>
+
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/snippets-create.mdx
+++ b/api-v1/post/snippets-create.mdx
@@ -1,0 +1,110 @@
+---
+title: "Create Snippet"
+api: "POST https://api.bland.ai/v1/snippets/create"
+description: "Upload a JavaScript snippet that can be executed by Custom Code Nodes or run directly."
+---
+
+Snippets are the JavaScript functions behind the [Custom Code Node](/enterprise-features/custom-code-node). They run securely on Bland's infrastructure.
+
+<Note>
+  Snippets require Custom Code access on your account. Reach out to Bland support to enable it.
+</Note>
+
+### Headers
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication.
+</ParamField>
+
+<ParamField header="content-type" type="string" required>
+  Set to `text/plain`. The request body is the raw script, not JSON.
+</ParamField>
+
+### Query Parameters
+
+<ParamField query="language" type="string" required>
+  Language of the snippet. Currently only `js` is supported.
+</ParamField>
+
+<ParamField query="name" type="string" required>
+  Name of the snippet. Maximum 100 characters. Only latin alphabet characters and underscores are allowed (no digits or spaces).
+</ParamField>
+
+### Body
+
+Send the snippet's source code as the raw request body, exactly as you would write it in an editor. Do not wrap it in JSON or minify it. Maximum length is 100,000 characters.
+
+Your snippet must export a default `fetch` handler and return JSON using `Response.json()`:
+
+```javascript
+export default {
+  async fetch(request, env, ctx) {
+    const input = await request.json();
+
+    return Response.json({
+      message: `Hello, ${input.name}`
+    });
+  }
+}
+```
+
+### Response
+
+<ResponseField name="data" type="object">
+  The created snippet.
+</ResponseField>
+
+<ResponseField name="data.snippet_id" type="string">
+  Unique identifier for the new snippet. Use this ID to update, run, or delete it.
+</ResponseField>
+
+<ResponseField name="data.submission" type="string">
+  The script exactly as it was received.
+</ResponseField>
+
+<ResponseField name="errors" type="null">
+  Error array (null on success).
+</ResponseField>
+
+<RequestExample>
+```bash Request
+curl --request POST \
+  --url 'https://api.bland.ai/v1/snippets/create?language=js&name=order_lookup' \
+  --header 'authorization: YOUR_API_KEY' \
+  --header 'content-type: text/plain' \
+  --data 'export default {
+  async fetch(request, env, ctx) {
+    const input = await request.json();
+    return Response.json({ message: `Hello, ${input.name}` });
+  }
+}'
+```
+</RequestExample>
+
+<ResponseExample>
+```json Response
+{
+  "data": {
+    "snippet_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "submission": "export default {\n  async fetch(request, env, ctx) {\n    const input = await request.json();\n    return Response.json({ message: `Hello, ${input.name}` });\n  }\n}"
+  },
+  "errors": null
+}
+```
+
+```json Validation Error
+{
+  "data": null,
+  "errors": [
+    {
+      "error": "SCRIPT_CREATE_VALIDATION_ERROR",
+      "message": "Script language must be provided as a query string. Add ?language=js to the URL."
+    }
+  ]
+}
+```
+</ResponseExample>
+
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/snippets-delete.mdx
+++ b/api-v1/post/snippets-delete.mdx
@@ -1,0 +1,68 @@
+---
+title: "Delete Snippet"
+api: "POST https://api.bland.ai/v1/snippets/delete"
+description: "Permanently delete a snippet and all of its versions."
+---
+
+<Warning>
+  Deleting a snippet removes every version and cannot be undone. Pathways with Custom Code Nodes that reference the snippet will no longer be able to run it.
+</Warning>
+
+### Headers
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication.
+</ParamField>
+
+### Body Parameters
+
+<ParamField body="snippet_id" type="string" required>
+  ID of the snippet to delete.
+</ParamField>
+
+### Response
+
+<ResponseField name="data" type="null">
+  Null on success.
+</ResponseField>
+
+<ResponseField name="errors" type="null">
+  Error array (null on success).
+</ResponseField>
+
+<RequestExample>
+```bash Request
+curl --request POST \
+  --url 'https://api.bland.ai/v1/snippets/delete' \
+  --header 'authorization: YOUR_API_KEY' \
+  --header 'content-type: application/json' \
+  --data '{
+    "snippet_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+  }'
+```
+</RequestExample>
+
+<ResponseExample>
+```json Response
+{
+  "data": null,
+  "errors": null
+}
+```
+
+```json Not Found
+{
+  "data": null,
+  "errors": [
+    {
+      "error": "SCRIPT_DELETE_FAILED",
+      "message": "Snippet not found"
+    }
+  ]
+}
+```
+</ResponseExample>
+
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/snippets-id-run.mdx
+++ b/api-v1/post/snippets-id-run.mdx
@@ -1,0 +1,134 @@
+---
+title: "Run Snippet"
+api: "POST https://api.bland.ai/v1/snippets/run/{snippet_id}"
+description: "Execute a snippet directly, outside of a pathway. Useful for testing."
+---
+
+Runs a snippet on Bland's infrastructure and returns its output. This is the same execution environment the [Custom Code Node](/enterprise-features/custom-code-node) uses during calls, so it is a convenient way to test a snippet before wiring it into a pathway.
+
+<Note>
+  The endpoint returns HTTP 200 even when the snippet itself fails. Check `data.success` and `data.response.error` to determine the outcome of the run.
+</Note>
+
+### Headers
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication.
+</ParamField>
+
+### Path Parameters
+
+<ParamField path="snippet_id" type="string" required>
+  ID of the snippet to run.
+</ParamField>
+
+### Body Parameters
+
+<ParamField body="payload" type="object">
+  Data passed to your snippet. Inside the snippet, read it with `await request.json()`.
+</ParamField>
+
+<ParamField body="headers" type="object">
+  Headers forwarded to your snippet's `request` object.
+</ParamField>
+
+<ParamField body="version" type="integer">
+  The snippet version to run. If not provided, the latest version is used, which adds a lookup delay to the execution time. Provide a version for the fastest execution.
+</ParamField>
+
+### Response
+
+<ResponseField name="data" type="object">
+  The result of the run.
+
+  <Expandable title="run result">
+    <ResponseField name="success" type="boolean">
+      Whether the snippet executed successfully.
+    </ResponseField>
+    <ResponseField name="response" type="object">
+      Details of the snippet's response.
+
+      <Expandable title="response object">
+        <ResponseField name="status_code" type="integer">
+          Status code returned by the snippet (200 to 500).
+        </ResponseField>
+        <ResponseField name="response_type" type="string">
+          Type of the response content. `json` or `text`.
+        </ResponseField>
+        <ResponseField name="exec_time" type="integer">
+          Execution time in milliseconds.
+        </ResponseField>
+        <ResponseField name="content" type="object | string">
+          The content returned by the snippet.
+        </ResponseField>
+        <ResponseField name="error" type="object">
+          Present when the run fails. Contains a `code` (for example `SNIPPET_TIMEOUT`, `SNIPPET_ERROR`, or `SNIPPET_INVALID_RESPONSE`) and a `message`.
+        </ResponseField>
+      </Expandable>
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="errors" type="null">
+  Error array (null unless the request itself fails).
+</ResponseField>
+
+### Snippet output requirements
+
+Your snippet must return JSON using `Response.json(<data>)`. HTML and plain text responses are rejected with a `SNIPPET_INVALID_RESPONSE` error.
+
+<RequestExample>
+```bash Request
+curl --request POST \
+  --url 'https://api.bland.ai/v1/snippets/run/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' \
+  --header 'authorization: YOUR_API_KEY' \
+  --header 'content-type: application/json' \
+  --data '{
+    "payload": { "name": "Ada" },
+    "headers": { "x-request-source": "docs-example" },
+    "version": 2
+  }'
+```
+</RequestExample>
+
+<ResponseExample>
+```json Response
+{
+  "data": {
+    "success": true,
+    "response": {
+      "status_code": 200,
+      "response_type": "json",
+      "exec_time": 312,
+      "content": {
+        "message": "Hi again, Ada"
+      }
+    }
+  },
+  "errors": null
+}
+```
+
+```json Failed Run
+{
+  "data": {
+    "success": false,
+    "response": {
+      "status_code": 500,
+      "response_type": "text",
+      "exec_time": 0,
+      "content": "",
+      "error": {
+        "code": "SNIPPET_TIMEOUT",
+        "message": "Request timed out"
+      }
+    }
+  },
+  "errors": null
+}
+```
+</ResponseExample>
+
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/api-v1/post/snippets-update.mdx
+++ b/api-v1/post/snippets-update.mdx
@@ -1,0 +1,93 @@
+---
+title: "Update Snippet"
+api: "POST https://api.bland.ai/v1/snippets/update"
+description: "Upload a new version of an existing snippet. Previous versions are kept."
+---
+
+Updating a snippet does not overwrite it. Each update creates a new version, and the previous versions remain available. Custom Code Nodes and [Run Snippet](/api-v1/post/snippets-id-run) use the latest version unless a specific version is requested.
+
+### Headers
+
+<ParamField header="authorization" type="string" required>
+  Your API key for authentication.
+</ParamField>
+
+<ParamField header="content-type" type="string" required>
+  Set to `text/plain`. The request body is the raw script, not JSON.
+</ParamField>
+
+### Query Parameters
+
+<ParamField query="snippet_id" type="string" required>
+  ID of the snippet to update.
+</ParamField>
+
+### Body
+
+Send the snippet's full source code as the raw request body, exactly as you would write it in an editor. Maximum length is 100,000 characters.
+
+### Response
+
+<ResponseField name="data" type="object">
+  The updated snippet.
+</ResponseField>
+
+<ResponseField name="data.snippet_id" type="string">
+  ID of the updated snippet.
+</ResponseField>
+
+<ResponseField name="data.version" type="integer">
+  The new version number created by this update.
+</ResponseField>
+
+<ResponseField name="data.submission" type="string">
+  The script exactly as it was received.
+</ResponseField>
+
+<ResponseField name="errors" type="null">
+  Error array (null on success).
+</ResponseField>
+
+<RequestExample>
+```bash Request
+curl --request POST \
+  --url 'https://api.bland.ai/v1/snippets/update?snippet_id=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' \
+  --header 'authorization: YOUR_API_KEY' \
+  --header 'content-type: text/plain' \
+  --data 'export default {
+  async fetch(request, env, ctx) {
+    const input = await request.json();
+    return Response.json({ message: `Hi again, ${input.name}` });
+  }
+}'
+```
+</RequestExample>
+
+<ResponseExample>
+```json Response
+{
+  "data": {
+    "snippet_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "version": 2,
+    "submission": "export default {\n  async fetch(request, env, ctx) {\n    const input = await request.json();\n    return Response.json({ message: `Hi again, ${input.name}` });\n  }\n}"
+  },
+  "errors": null
+}
+```
+
+```json Validation Error
+{
+  "data": null,
+  "errors": [
+    {
+      "error": "SCRIPT_UPDATE_VALIDATION_ERROR",
+      "message": "Snippet ID must be provided as a query string. Add ?snippet_id= to the URL."
+    }
+  ]
+}
+```
+</ResponseExample>
+
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/docs.json
+++ b/docs.json
@@ -336,6 +336,17 @@
                 ]
               },
               {
+                "group": "Custom Code Snippets",
+                "pages": [
+                  "api-v1/post/snippets-create",
+                  "api-v1/post/snippets-update",
+                  "api-v1/get/snippets-list",
+                  "api-v1/get/snippets-id",
+                  "api-v1/post/snippets-id-run",
+                  "api-v1/post/snippets-delete"
+                ]
+              },
+              {
                 "group": "Contacts",
                 "pages": [
                   "api-v1/get/contacts",

--- a/llms.txt
+++ b/llms.txt
@@ -248,6 +248,15 @@ Generate speech from text, manage Bland TTS voices, and clone custom voices. The
 - [List Custom Tools (Legacy)](https://docs.bland.ai/api-v1/get/tools.md): Retrieve legacy custom tools you've created.
 - [Custom Tool Details (Legacy)](https://docs.bland.ai/api-v1/get/tools-tool-id.md): Retrieve a specific legacy custom tool.
 
+## API Reference: Custom Code Snippets
+
+- [Create Snippet](https://docs.bland.ai/api-v1/post/snippets-create.md): Upload a JavaScript snippet that can be executed by Custom Code Nodes or run directly.
+- [Update Snippet](https://docs.bland.ai/api-v1/post/snippets-update.md): Upload a new version of an existing snippet. Previous versions are kept.
+- [List Snippets](https://docs.bland.ai/api-v1/get/snippets-list.md): List your organization's snippets at their latest version.
+- [Get Snippet](https://docs.bland.ai/api-v1/get/snippets-id.md): Retrieve a snippet's source code, either the latest version or all versions.
+- [Run Snippet](https://docs.bland.ai/api-v1/post/snippets-id-run.md): Execute a snippet directly, outside of a pathway. Useful for testing.
+- [Delete Snippet](https://docs.bland.ai/api-v1/post/snippets-delete.md): Permanently delete a snippet and all of its versions.
+
 ## API Reference: Contacts
 
 - [List Contacts](https://docs.bland.ai/api-v1/get/contacts.md): List all contacts for your organization with identifiers and memory entities.


### PR DESCRIPTION
Adds API reference pages for the `v1/snippets` endpoints (Custom Code Snippets): create, update, list, get, run, and delete. Also adds a "Custom Code Snippets" group to `docs.json` navigation and matching entries in `llms.txt`.

Verified locally with `mint dev` (all pages render), `mint broken-links`, and `mint a11y`.