### PR TITLE
Agent speech: adaptive resumption, node-scoped interruptibility

### DIFF
--- a/api-v1/post/calls.mdx
+++ b/api-v1/post/calls.mdx
@@ -231,16 +231,6 @@ Send an AI phone call with a custom objective and actions. This endpoint can be 
   Lower values mean the AI will respond more quickly, while higher values mean the AI will wait longer before responding.
 </ParamField>
 
-<ParamField body="resumption_speed" default="2" type="integer">
-  Controls how quickly the AI starts speaking again after the caller finishes a turn. A lower value responds sooner; a higher value waits longer, leaving more room for the caller to continue.
-
-  - `1`: Fast. Responds sooner after the caller pauses.
-  - `2`: Medium (default).
-  - `3`: Slow. Waits longer before responding.
-
-  Supersedes `interruption_threshold`. When both are sent, `resumption_speed` takes precedence.
-</ParamField>
-
 <ParamField body="interruptibility" default="2" type="integer">
   Controls how readily the AI stops speaking when the caller talks over it. A higher value yields more easily; a lower value holds the turn through more of the caller's speech.
 

--- a/api-v1/post/update_pathways.mdx
+++ b/api-v1/post/update_pathways.mdx
@@ -212,10 +212,8 @@ description: "Update a conversational pathway's fields - including name, descrip
           — The name of the model to be used for this node.
         - `interruptionThreshold`
             — The sensitivity to interruptions at this node
-        - `resumption_speed`
-          — How quickly the AI starts speaking again after the caller finishes a turn while on this node: `1` fast, `2` medium (default), `3` slow. Supersedes `interruptionThreshold` when both are set. Useful per node: e.g. slow on a data-collection node so the caller can finish their digits.
         - `interruptibility`
-          — How readily the AI stops speaking when the caller talks over it on this node: `0` block (the AI finishes speaking, same as `block_interruptions: true`), `1` difficult, `2` balanced (default), `3` easy. Useful per node: e.g. difficult on a legal-disclaimer node.
+          — How readily the AI stops speaking when the caller talks over it on this node: `0` block (the AI finishes speaking, same as `block_interruptions: true`), `1` difficult, `2` balanced (default), `3` easy. Applies only while this node is active; other nodes use the agent's setting. Useful per node: e.g. difficult on a legal-disclaimer node.
         - `temperature`
           — The temperature of the model.
       - `extractVars`

--- a/changelog/08_03_2026.mdx
+++ b/changelog/08_03_2026.mdx
@@ -5,6 +5,10 @@ description: 'Adaptive resumption and node-scoped interruptibility'
 
 ### Adaptive resumption
 
+<Note>
+Rolling out now; may not yet be active in your environment.
+</Note>
+
 Agents now adapt their response timing to each caller automatically. The agent
 measures the caller's pace — how long their speech runs and how long their
 mid-thought pauses last — and waits accordingly before taking its turn: fast

--- a/changelog/08_03_2026.mdx
+++ b/changelog/08_03_2026.mdx
@@ -1,0 +1,25 @@
+---
+title: 'August 3, 2026'
+description: 'Adaptive resumption and node-scoped interruptibility'
+---
+
+### Adaptive resumption
+
+Agents now adapt their response timing to each caller automatically. The agent
+measures the caller's pace — how long their speech runs and how long their
+mid-thought pauses last — and waits accordingly before taking its turn: fast
+callers get near-instant responses, deliberate callers get an agent that waits
+out thinking pauses instead of jumping in, and a caller who changes pace
+mid-call is matched within about fifteen seconds.
+
+- Nothing to configure. The `resumption_speed` field is removed; response
+  timing no longer has a manual setting.
+- Works on every call, in both directions: slowing down earns patience, and
+  speeding back up restores snappy responses.
+
+### Node-scoped interruptibility
+
+Per-node interruptibility settings on pathways now apply only while that node
+is active. Leaving a node that declares a setting reverts to the agent's own
+setting instead of carrying the node's value for the rest of the call. The
+same applies to per-node interruption thresholds.

--- a/docs.json
+++ b/docs.json
@@ -802,6 +802,7 @@
           {
             "group": "Change Log",
             "pages": [
+              "changelog/08_03_2026",
               "changelog/07_21_2026",
               "changelog/07_06_2026",
               "changelog/05_28_2026",

--- a/tutorials/agent-speech.mdx
+++ b/tutorials/agent-speech.mdx
@@ -41,7 +41,7 @@ How readily the agent yields the floor when the caller speaks over it. Set with 
 ## Adaptive resumption
 
 <Note>
-Adaptive resumption is rolling out and may not yet be active in your environment. Where it is not, the agent's previous response timing remains in effect.
+Adaptive resumption is rolling out and may not yet be active in your environment.
 </Note>
 
 How quickly the agent responds once the caller stops talking is measured per caller, per call. The agent tracks the caller's own rhythm — how long their speech runs and how long their mid-thought pauses last — and adjusts how long it waits before taking its turn:

--- a/tutorials/agent-speech.mdx
+++ b/tutorials/agent-speech.mdx
@@ -40,6 +40,10 @@ How readily the agent yields the floor when the caller speaks over it. Set with 
 
 ## Adaptive resumption
 
+<Note>
+Adaptive resumption is rolling out and may not yet be active in your environment. Where it is not, the agent's previous response timing remains in effect.
+</Note>
+
 How quickly the agent responds once the caller stops talking is measured per caller, per call. The agent tracks the caller's own rhythm — how long their speech runs and how long their mid-thought pauses last — and adjusts how long it waits before taking its turn:
 
 - A caller who speaks quickly, without hesitating, gets near-instant responses.

--- a/tutorials/agent-speech.mdx
+++ b/tutorials/agent-speech.mdx
@@ -3,12 +3,10 @@ title: "Agent Speech"
 description: "Control how readily your agent pauses for callers and how quickly it responds after they stop talking."
 ---
 
-Two settings control how your agent shares the conversation:
+Two behaviors control how your agent shares the conversation:
 
-- **Interruptibility** governs what happens while the agent is speaking: how readily it yields when the caller talks over it.
-- **Resumption speed** governs what happens after the caller finishes: how quickly the agent takes its turn.
-
-They are independent, and both are optional. An agent with neither set uses the balanced defaults described below.
+- **Interruptibility** governs what happens while the agent is speaking: how readily it yields when the caller talks over it. This is a setting you choose.
+- **Resumption** governs what happens after the caller finishes: how quickly the agent takes its turn. This is adaptive: the agent measures each caller's pace and matches it automatically. There is nothing to configure.
 
 ## Agent pauses
 
@@ -40,37 +38,27 @@ How readily the agent yields the floor when the caller speaks over it. Set with 
 | Difficult | `1` | Holds the turn longer and treats more caller speech as acknowledgment. Good for noisy lines and chatty listeners. |
 | Block interruptions | `0` | The agent ignores caller speech entirely while talking and always finishes what it is saying. |
 
-## Resumption speed
+## Adaptive resumption
 
-How quickly the agent responds once the caller stops talking. Set with the `resumption_speed` field (integer, `1`-`3`, default `2`).
+How quickly the agent responds once the caller stops talking is measured per caller, per call. The agent tracks the caller's own rhythm — how long their speech runs and how long their mid-thought pauses last — and adjusts how long it waits before taking its turn:
 
-| Setting | API value | Caller experience |
-| :---- | :---- | :---- |
-| Fast | `1` | Responds almost as soon as the caller stops. Snappy, suited to quick transactional exchanges. May jump in when a caller pauses mid-thought. |
-| Medium | `2` | Default. Balanced for most conversations. |
-| Slow | `3` | Leaves a deliberate beat before responding. Suited to callers who pause to think mid-answer: the agent does not take a thinking pause as its cue to speak. |
+- A caller who speaks quickly, without hesitating, gets near-instant responses.
+- A caller who speaks deliberately, pausing mid-sentence to think or to read out a number, gets an agent that waits out those pauses instead of jumping in, up to about two and a half seconds.
+- A caller who changes pace mid-call is matched within about fifteen seconds.
 
-<Note>
-`resumption_speed` supersedes the older `interruption_threshold` field. When both are set, `resumption_speed` wins. Prefer `resumption_speed` for new configurations; `interruption_threshold` remains accepted for backward compatibility.
-</Note>
+The adaptation runs continuously in both directions: slowing down earns patience, and speeding back up restores snappy responses.
 
-## Where to set them
+## Where to set interruptibility
 
-- **Send Call API**: pass `interruptibility` and `resumption_speed` in the [`/v1/calls`](/api-v1/post/calls) request body. They apply to the whole call.
-- **Inbound numbers**: the same fields on your inbound number configuration.
-- **Pathways**: per node, in the node inspector under Advanced options.
-
-<Warning>
-A node's setting stays in force for the rest of the call, not just that node, unless a later node changes it. If the agent misbehaves at a node with no setting of its own, check the nodes before it.
-</Warning>
+- **Send Call API**: pass `interruptibility` in the [`/v1/calls`](/api-v1/post/calls) request body. It applies to the whole call.
+- **Inbound numbers**: the same field on your inbound number configuration.
+- **Pathways**: per node, in the node inspector under Advanced options. A node's setting applies only while that node is active; other nodes use the agent's own setting.
 
 ## Choosing values
 
 | Symptom | Try |
 | :---- | :---- |
-| The agent takes too long to respond | Fast resumption |
-| The agent jumps in while callers are still thinking | Slow resumption |
 | The agent talks over callers who want to say something | Easy interruptibility, or Always interrupt |
 | The agent stops for background noise or brief acknowledgments | Difficult interruptibility, or Block interruptions |
 
-The two combine. A common "let the caller drive" setup is Easy interruptibility with Slow resumption; a common "get through the script" setup is Difficult interruptibility with Fast resumption.
+Response timing needs no tuning: an agent that seems to jump in on a hesitant caller will settle within a few turns as the measurement catches up to the caller's pace.


### PR DESCRIPTION
- **Adaptive resumption replaces the resumption_speed levels.** The tutorial's Resumption speed section becomes Adaptive resumption (measured per-caller pace, near-instant for fast callers, up to ~2.5s patience for deliberate ones, ~15s to match a mid-call pace change, adapts in both directions). The `resumption_speed` ParamField is removed from the Send Call API doc and the per-node bullet from the pathway update doc; the field was live only briefly and had no adopters. The interruption_threshold supersession note goes with it.
- **Interruptibility is documented as node-scoped.** A node's setting applies only while that node is active; the old cascade warning is replaced accordingly in the tutorial and the pathway doc.
- **Changelog entry for August 3** covering both, registered in the nav.

Server changes: CINTELLILABS/SERVER#10031, CINTELLILABS/SERVER#10024, CINTELLILABS/SERVER#9920.

🤖 Generated with [Claude Code](https://claude.com/claude-code)