### PR TITLE
CUS-1094 add speech/limits page (concurrency, clone limits, $5 unlock)

### DIFF
--- a/api-v1/post/speak.mdx
+++ b/api-v1/post/speak.mdx
@@ -24,14 +24,7 @@ For lower-latency streaming with chunked WAV-header backfill, use [Stream Speech
 
 ## Pricing
 
-Text-to-speech pricing scales with plan:
-
-| Plan | Rate |
-|---|---|
-| Start | $0.02 per 100 characters |
-| Build | $0.02 per 150 characters |
-| Scale | $0.02 per 200 characters |
-| Enterprise | $0.02 per 400 characters |
+Text-to-speech is currently billed at **\$0.015 per 1,000 characters**, the same rate on every plan. This is a limited-time launch offer, discounted from the standard \$0.04 per 1,000 characters. Each request carries a minimum charge of \$0.001, so very short generations bill at the minimum rather than the per-character rate.
 
 Some voices in the public library carry an additional per-character creator fee. The exact cost for a generation is returned in the `x-cost` response header.
 

--- a/api-v2/post/tts.mdx
+++ b/api-v2/post/tts.mdx
@@ -25,14 +25,7 @@ Turns text into speech and streams the audio back as it renders.
 
 ## Pricing
 
-Text-to-speech pricing scales with plan:
-
-| Plan | Rate |
-|---|---|
-| Start | $0.02 per 100 characters |
-| Build | $0.02 per 150 characters |
-| Scale | $0.02 per 200 characters |
-| Enterprise | $0.02 per 400 characters |
+Text-to-speech is currently billed at **\$0.015 per 1,000 characters**, the same rate on every plan. This is a limited-time launch offer, discounted from the standard \$0.04 per 1,000 characters. Each request carries a minimum charge of \$0.001, so very short generations bill at the minimum rather than the per-character rate.
 
 Some public-library voices carry an additional per-character creator fee. The exact charge for a request comes back in the `x-cost` header.
 

--- a/docs.json
+++ b/docs.json
@@ -81,7 +81,7 @@
               },
               {
                 "group": "Platform Information",
-                "pages": ["platform/static-ips", "platform/billing"]
+                "pages": ["platform/static-ips", "platform/billing", "speech/limits"]
               },
               {
                 "group": "SDKs & Tools",

--- a/docs.json
+++ b/docs.json
@@ -729,7 +729,7 @@
             "group": "Get Started",
             "pages": [
               "tts/welcome",
-                  "speech/limits",
+              "speech/limits",
               "sdks/bland-tts",
               "tutorials/btts"
             ]

--- a/llms.txt
+++ b/llms.txt
@@ -114,6 +114,11 @@ Bland holds SOC 2 Type II, HIPAA, GDPR, and PCI DSS certifications. Self-hosted 
 - [Create Post Call Webhook](https://docs.bland.ai/api-v1/post/postcall-webhooks-create.md): Create and send post call webhooks for specified calls.
 - [Resend Post Call Webhook](https://docs.bland.ai/api-v1/post/postcall-webhooks-resend.md): Resend post call webhooks for specified calls.
 
+## Bland Speech
+
+- [Welcome to Bland Speech](https://docs.bland.ai/tts/welcome.md): Humanlike text-to-speech built for real conversations. Product overview and where to start.
+- [Speech Limits](https://docs.bland.ai/speech/limits.md): Concurrency, voice clone, and professional clone limits for Bland Speech, plus the one-time $5 unlock and how to raise limits.
+
 ## API Reference: Voices & Text to Speech
 
 Generate speech from text, manage Bland TTS voices, and clone custom voices. The dashboard surface for these APIs lives at app.bland.ai/dashboard/tts.

--- a/speech/limits.mdx
+++ b/speech/limits.mdx
@@ -10,12 +10,14 @@ Bland Speech is pay-as-you-go: generation is billed per character against your w
 | Limit | Before your first top-up | After a one-time $5 top-up |
 | --- | --- | --- |
 | Concurrent generations | 1 | 5 |
-| Instant voice clones | 0 | 10 |
+| Instant voice clones | 1 | 10 |
 | Live professional clones | 0 | 1 |
 
 The unlock is **cumulative and permanent**: once your total wallet deposits reach $5, the higher limits apply for the life of the organization — they are not tied to your current balance. The starting credit new accounts receive does not count toward the $5.
 
 ## Instant voice clones
+
+Every organization can create **one** instant clone before its first top-up, so you can try cloning before funding your wallet; the one-time $5 top-up raises the limit to 10.
 
 Instant clone limits are counted **per organization, in aggregate across all voice model generations**. If your limit is 10, that is 10 cloned voices total — not 10 per model version.
 

--- a/speech/limits.mdx
+++ b/speech/limits.mdx
@@ -1,0 +1,56 @@
+---
+title: "Speech Limits"
+description: "Concurrency, voice clone, and professional clone limits for Bland Speech — what they are, how the $5 unlock works, and how to raise them."
+---
+
+Bland Speech is pay-as-you-go: generation is billed per character against your wallet balance, and there are no subscription tiers. Limits are per organization and are unlocked by funding your wallet.
+
+## Default limits
+
+| Limit | Before your first top-up | After a one-time $5 top-up |
+| --- | --- | --- |
+| Concurrent generations | 1 | 5 |
+| Instant voice clones | 0 | 10 |
+| Live professional clones | 0 | 1 |
+
+The unlock is **cumulative and permanent**: once your total wallet deposits reach $5, the higher limits apply for the life of the organization — they are not tied to your current balance. The starting credit new accounts receive does not count toward the $5.
+
+## Instant voice clones
+
+Instant clone limits are counted **per organization, in aggregate across all voice model generations**. If your limit is 10, that is 10 cloned voices total — not 10 per model version.
+
+The limit applies when creating a new clone; existing voices are never affected by a limit change. Limits are raisable — see [Raising your limits](#raising-your-limits).
+
+## Concurrency and the 429 response
+
+Your concurrency limit is the number of speech generations you may have **in flight at the same moment**, across every speech surface: `POST /v1/speak`, `POST /v1/speak/stream`, `POST /v1/voices/{id}/speak`, streaming input over WebSocket, and shared audio links (which count against the link owner's organization).
+
+When you exceed it, the API responds `429` with:
+
+```json
+{
+  "error": "concurrency_limit_reached",
+  "limit": 5,
+  "message": "You're at 5 concurrent generations. Email tts@bland.ai to raise your limit.",
+  "docs": "https://docs.bland.ai/speech/limits"
+}
+```
+
+**This is not ordinary rate limiting.** A rate limit meters requests per unit of time; the concurrency limit only counts generations that are still running. A slot frees the moment one of your generations finishes, so the correct client behavior is:
+
+- Wait the number of **seconds** given in the `Retry-After` header (it is seconds, not milliseconds), then retry.
+- Or simply await one of your in-flight generations before submitting the next.
+
+Avoid tight retry loops — they cannot make a slot free faster, and the wait is typically only a few seconds.
+
+## Professional clones
+
+Professional (studio-trained) voices follow a **draft / live** model:
+
+- You may hold **unlimited drafts**. Drafts can be trained and previewed in the studio, but cannot be downloaded, used through the API, or used in calls.
+- You may promote up to your live limit (default **1** after the $5 unlock). Only live voices are usable everywhere.
+- Training a professional voice requires a funded organization (the $5 unlock) and passing Bland's **consent and rights review** for the voice being cloned.
+
+## Raising your limits
+
+Email [tts@bland.ai](mailto:tts@bland.ai) with your organization ID, the limit you're hitting (instant clones, live professional clones, or concurrency), and a sentence about your use case. Raises are applied directly to your organization — no plan change required.

--- a/speech/limits.mdx
+++ b/speech/limits.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Speech Limits"
-description: "Concurrency, voice clone, and professional clone limits for Bland Speech — what they are, how the $5 unlock works, and how to raise them."
+description: "Concurrency, voice clone, and professional clone limits for Bland Speech: what they are, how the $5 unlock works, and how to raise them."
 ---
 
 Bland Speech is pay-as-you-go: generation is billed per character against your wallet balance, and there are no subscription tiers. Limits are per organization and are unlocked by funding your wallet.
@@ -13,15 +13,15 @@ Bland Speech is pay-as-you-go: generation is billed per character against your w
 | Instant voice clones | 1 | 10 |
 | Live professional clones | 0 | 1 |
 
-The unlock is **cumulative**: once your total wallet deposits reach \$5, the higher limits apply — they are not tied to your current balance, so spending your wallet down doesn't lower them. The starting credit new accounts receive does not count toward the \$5.
+The unlock is **cumulative**: once your total wallet deposits reach \$5, the higher limits apply. They are not tied to your current balance, so spending your wallet down doesn't lower them. The starting credit new accounts receive does not count toward the \$5.
 
 ## Instant voice clones
 
 Every organization can create **one** instant clone before its first top-up, so you can try cloning before funding your wallet; the one-time \$5 top-up raises the limit to 10.
 
-Instant clone limits are counted per organization against your **current-generation (V3) voices**. Voice clones created with earlier model generations don't count against the limit. If your limit is 10, that's 10 active V3 clones — deleting one frees the slot.
+Instant clone limits are counted per organization against your **current-generation (V3) voices**. Voice clones created with earlier model generations don't count against the limit. If your limit is 10, that's 10 active V3 clones, and deleting one frees the slot.
 
-The limit applies when creating a new clone; existing voices are never affected by a limit change. Limits are raisable — see [Raising your limits](#raising-your-limits).
+The limit applies when creating a new clone; existing voices are never affected by a limit change. Limits are raisable; see [Raising your limits](#raising-your-limits).
 
 ## Concurrency and the 429 response
 
@@ -43,7 +43,7 @@ When you exceed it, the API responds `429` with:
 - Wait the number of **seconds** given in the `Retry-After` header (it is seconds, not milliseconds), then retry.
 - Or simply await one of your in-flight generations before submitting the next.
 
-Avoid tight retry loops — they cannot make a slot free faster, and the wait is typically only a few seconds.
+Avoid tight retry loops. They cannot make a slot free faster, and the wait is typically only a few seconds.
 
 ## Professional clones
 
@@ -55,6 +55,10 @@ Professional (studio-trained) voices follow a **draft / live** model:
 
 ## Raising your limits
 
-If you haven't made your first top-up yet, the \$5 unlock *is* the raise — it takes you to 10 instant clones, 1 live professional clone, and 5 concurrent generations.
+If you haven't made your first top-up yet, the \$5 unlock *is* the raise. It takes you to 10 instant clones, 1 live professional clone, and 5 concurrent generations.
 
-To go beyond the unlocked limits: for **instant clones** and **live professional clones**, use the **Request a raise** option in the studio (on the billing page when you're at your limit, or in the clone dialog) — requests are reviewed by hand and answered by email. For **concurrency**, email [tts@bland.ai](mailto:tts@bland.ai) with your organization ID and expected volume — those are sized case by case. Raises are applied directly to your organization — no plan change required.
+To go beyond the unlocked limits: for **instant clones** and **live professional clones**, use the **Request a raise** option in the studio (on the billing page when you're at your limit, or in the clone dialog); requests are reviewed by hand and answered by email. For **concurrency**, email [tts@bland.ai](mailto:tts@bland.ai) with your organization ID and expected volume, and those are sized case by case. Raises are applied directly to your organization, no plan change required.
+
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/speech/limits.mdx
+++ b/speech/limits.mdx
@@ -7,17 +7,17 @@ Bland Speech is pay-as-you-go: generation is billed per character against your w
 
 ## Default limits
 
-| Limit | Before your first top-up | After a one-time $5 top-up |
+| Limit | Before your first top-up | After a one-time \$5 top-up |
 | --- | --- | --- |
 | Concurrent generations | 1 | 5 |
 | Instant voice clones | 1 | 10 |
 | Live professional clones | 0 | 1 |
 
-The unlock is **cumulative and permanent**: once your total wallet deposits reach $5, the higher limits apply for the life of the organization — they are not tied to your current balance. The starting credit new accounts receive does not count toward the $5.
+The unlock is **cumulative**: once your total wallet deposits reach \$5, the higher limits apply — they are not tied to your current balance, so spending your wallet down doesn't lower them. The starting credit new accounts receive does not count toward the \$5.
 
 ## Instant voice clones
 
-Every organization can create **one** instant clone before its first top-up, so you can try cloning before funding your wallet; the one-time $5 top-up raises the limit to 10.
+Every organization can create **one** instant clone before its first top-up, so you can try cloning before funding your wallet; the one-time \$5 top-up raises the limit to 10.
 
 Instant clone limits are counted per organization against your **current-generation (V3) voices**. Voice clones created with earlier model generations don't count against the limit. If your limit is 10, that's 10 active V3 clones — deleting one frees the slot.
 
@@ -50,11 +50,11 @@ Avoid tight retry loops — they cannot make a slot free faster, and the wait is
 Professional (studio-trained) voices follow a **draft / live** model:
 
 - You may hold **unlimited drafts**. Drafts can be trained and previewed in the studio, but cannot be downloaded, used through the API, or used in calls.
-- You may promote up to your live limit (default **1** after the $5 unlock). Only live voices are usable everywhere.
-- Training a professional voice requires a funded organization (the $5 unlock) and passing Bland's **consent and rights review** for the voice being cloned.
+- You may promote up to your live limit (default **1** after the \$5 unlock). Only live voices are usable everywhere.
+- Training a professional voice requires a funded organization (the \$5 unlock) and passing Bland's **consent and rights review** for the voice being cloned.
 
 ## Raising your limits
 
-If you haven't made your first top-up yet, the $5 unlock *is* the raise — it takes you to 10 instant clones, 1 live professional clone, and 5 concurrent generations.
+If you haven't made your first top-up yet, the \$5 unlock *is* the raise — it takes you to 10 instant clones, 1 live professional clone, and 5 concurrent generations.
 
 To go beyond the unlocked limits: for **instant clones** and **live professional clones**, use the **Request a raise** option in the studio (on the billing page when you're at your limit, or in the clone dialog) — requests are reviewed by hand and answered by email. For **concurrency**, email [tts@bland.ai](mailto:tts@bland.ai) with your organization ID and expected volume — those are sized case by case. Raises are applied directly to your organization — no plan change required.


### PR DESCRIPTION
Adds `docs.bland.ai/speech/limits` — the page the Speech concurrency 429 body links to (SERVER stack CINTELLILABS/SERVER#10128–#10133, Linear CUS-1088/CUS-1094).

**Content:** default limits table (unfunded 1 concurrent / no clones; one $5 top-up → 10 instant clones, 1 live professional clone, 5 concurrent); aggregate per-org clone counting; what `concurrency_limit_reached` means, that `Retry-After` is in **seconds**, and how it differs from rate limiting; professional draft/live model + consent review; escalation via tts@bland.ai.

**Draft because:** launch-blocking but blocked on tts@bland.ai being confirmed live (ops task on CUS-1088), and it must merge only alongside/after the SERVER enforcement PRs so published numbers match production. Numbers here match the stack's enforced values exactly.