### PR TITLE
CUS-1119: TTS product switcher and Bland Speech welcome page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -9,17 +9,18 @@
   },
   "favicon": "/favicon.png",
   "navigation": {
-    "anchors": [
+    "products": [
       {
-        "anchor": "Documentation",
-        "icon": "book-open",
+        "product": "Voice Agents",
         "tabs": [
           {
             "tab": "Documentation",
             "groups": [
               {
                 "group": "Welcome",
-                "pages": ["welcome-to-bland"]
+                "pages": [
+                  "welcome-to-bland"
+                ]
               },
               {
                 "group": "Core Bland Features",
@@ -55,7 +56,9 @@
               },
               {
                 "group": "Basic Tutorials",
-                "pages": ["tutorials/batch-calls"]
+                "pages": [
+                  "tutorials/batch-calls"
+                ]
               },
               {
                 "group": "Advanced Features",
@@ -82,7 +85,10 @@
               },
               {
                 "group": "Platform Information",
-                "pages": ["platform/static-ips", "platform/billing"]
+                "pages": [
+                  "platform/static-ips",
+                  "platform/billing"
+                ]
               },
               {
                 "group": "SDKs & Tools",
@@ -151,74 +157,6 @@
                       "api-v1/get/postcall-webhooks-get",
                       "api-v1/post/postcall-webhooks-create",
                       "api-v1/post/postcall-webhooks-resend"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Voices & Text to Speech",
-                "pages": [
-                  {
-                    "group": "Voices",
-                    "pages": [
-                      "api-v1/get/voices",
-                      "api-v1/get/voices-id",
-                      "api-v1/get/voices-id-settings",
-                      "api-v1/post/voices-id-settings",
-                      "api-v1/patch/voices-id-config",
-                      "api-v1/patch/voices-id-rename",
-                      "api-v1/post/voices-id-rate",
-                      "api-v1/delete/voices-id"
-                    ]
-                  },
-                  {
-                    "group": "Speech Generation",
-                    "pages": [
-                      "api-v2/post/tts",
-                      "api-v2/post/tts-live",
-                      "api-v2/get/tts-models",
-                      "api-v1/post/speak"
-                    ]
-                  },
-                  {
-                    "group": "Streaming",
-                    "pages": [
-                      "api-v1/post/speak-stream",
-                      "api-v1/post/speak-stream-input-token",
-                      "api-v1/post/speak-stream-input"
-                    ]
-                  },
-                  {
-                    "group": "Discovery",
-                    "pages": [
-                      "api-v1/post/voices-check-name-availability",
-                      "api-v1/get/voices-shared",
-                      "api-v1/post/voices-library-add-id"
-                    ]
-                  },
-                  {
-                    "group": "Voice Cloning",
-                    "pages": ["api-v1/post/clone"]
-                  },
-                  {
-                    "group": "Generation History",
-                    "pages": [
-                      "api-v1/get/speak-samples",
-                      "api-v1/get/speak-samples-id"
-                    ]
-                  },
-                  {
-                    "group": "Models",
-                    "pages": ["api-v1/get/models"]
-                  },
-                  {
-                    "group": "Samples",
-                    "pages": [
-                      "api-v1/get/voices-id-samples",
-                      "api-v1/post/voices-samples",
-                      "api-v1/get/voices-id-samples-sample-id",
-                      "api-v1/patch/voices-id-samples",
-                      "api-v1/delete/voices-id-samples"
                     ]
                   }
                 ]
@@ -583,7 +521,9 @@
               },
               {
                 "group": "Account",
-                "pages": ["api-v1/get/me"]
+                "pages": [
+                  "api-v1/get/me"
+                ]
               },
               {
                 "group": "Organizations",
@@ -783,23 +723,83 @@
         ]
       },
       {
-        "anchor": "Community & Support",
-        "href": "https://discord.gg/QvxDz8zcKe",
-        "icon": "discord"
+        "product": "TTS",
+        "groups": [
+          {
+            "group": "Get Started",
+            "pages": [
+              "tts/welcome",
+              "sdks/bland-tts",
+              "tutorials/btts"
+            ]
+          },
+          {
+            "group": "Speech Generation",
+            "pages": [
+              "api-v2/post/tts"
+            ]
+          },
+          {
+            "group": "Streaming",
+            "pages": [
+              "api-v2/post/tts-live"
+            ]
+          },
+          {
+            "group": "Voice Cloning",
+            "pages": [
+              "api-v1/post/clone"
+            ]
+          },
+          {
+            "group": "Voices",
+            "pages": [
+              "api-v1/get/voices",
+              "api-v1/get/voices-id",
+              "api-v1/get/voices-id-settings",
+              "api-v1/post/voices-id-settings",
+              "api-v1/patch/voices-id-config",
+              "api-v1/patch/voices-id-rename",
+              "api-v1/post/voices-id-rate",
+              "api-v1/delete/voices-id"
+            ]
+          },
+          {
+            "group": "Discovery",
+            "pages": [
+              "api-v1/post/voices-check-name-availability",
+              "api-v1/get/voices-shared",
+              "api-v1/post/voices-library-add-id"
+            ]
+          },
+          {
+            "group": "Samples",
+            "pages": [
+              "api-v1/get/voices-id-samples",
+              "api-v1/post/voices-samples",
+              "api-v1/get/voices-id-samples-sample-id",
+              "api-v1/patch/voices-id-samples",
+              "api-v1/delete/voices-id-samples"
+            ]
+          },
+          {
+            "group": "Generation History",
+            "pages": [
+              "api-v1/get/speak-samples",
+              "api-v1/get/speak-samples-id"
+            ]
+          },
+          {
+            "group": "Models",
+            "pages": [
+              "api-v2/get/tts-models",
+              "api-v1/get/models"
+            ]
+          }
+        ]
       },
       {
-        "anchor": "Blog",
-        "href": "https://www.bland.ai/blog",
-        "icon": "newspaper"
-      },
-      {
-        "anchor": "Enterprise inquiries",
-        "href": "https://www.bland.ai/book-a-demo",
-        "icon": "building"
-      },
-      {
-        "anchor": "Changelog",
-        "icon": "clock",
+        "product": "Changelog",
         "groups": [
           {
             "group": "Change Log",
@@ -819,7 +819,10 @@
               },
               {
                 "group": "March 2026",
-                "pages": ["changelog/03_23_2026", "changelog/03_11_2026"]
+                "pages": [
+                  "changelog/03_23_2026",
+                  "changelog/03_11_2026"
+                ]
               },
               {
                 "group": "February 2026",
@@ -915,7 +918,26 @@
           }
         ]
       }
-    ]
+    ],
+    "global": {
+      "anchors": [
+        {
+          "anchor": "Community & Support",
+          "href": "https://discord.gg/QvxDz8zcKe",
+          "icon": "discord"
+        },
+        {
+          "anchor": "Blog",
+          "href": "https://www.bland.ai/blog",
+          "icon": "newspaper"
+        },
+        {
+          "anchor": "Enterprise inquiries",
+          "href": "https://www.bland.ai/book-a-demo",
+          "icon": "building"
+        }
+      ]
+    }
   },
   "logo": {
     "light": "/logo/light.svg",

--- a/tts/welcome.mdx
+++ b/tts/welcome.mdx
@@ -1,0 +1,56 @@
+---
+title: "Welcome to Bland Speech"
+description: "A humanlike text-to-speech model built for real conversations."
+---
+
+Bland Speech is a text-to-speech model built for live conversation. It captures the breath, pacing, hesitation, and emotional movement that make speech feel real, so a synthetic voice reads like a person rather than a narrator.
+
+Most TTS is built around clean studio reads: audiobooks, voiceover, promo. Bland Speech is built for the moments where synthetic speech usually breaks: pauses, names, numbers, emotion, mid-sentence changes, and everything else a phone call throws at a voice.
+
+## What makes it different
+
+<CardGroup cols={2}>
+  <Card title="Human-like realism" icon="user-large">
+    Breath, pacing, hesitation, cadence, emotional movement. Not a polished studio read, a voice that sounds like a person.
+  </Card>
+  <Card title="Built for real conversations" icon="phone">
+    Timing, interruptions, mid-thought changes. Tuned for live speech, not narration.
+  </Card>
+  <Card title="Audio realism as the goal" icon="waveform">
+    Judged on how real the audio sounds against the same text and the same voice, not on a checklist of features.
+  </Card>
+  <Card title="Direct in plain language" icon="wand-magic-sparkles">
+    Say `warmer`, `more tired`, or `slower at the end`. No prompt tags, no sliders, no grammar to memorize.
+  </Card>
+</CardGroup>
+
+## Start here
+
+<CardGroup cols={2}>
+  <Card title="Bland TTS SDK" icon="terminal" href="/sdks/bland-tts">
+    Focused CLI, Node library, and MCP server. The fastest path from install to first audio.
+  </Card>
+  <Card title="Synthesize Speech" icon="code" href="/api-v2/post/tts">
+    `POST /v2/tts`. Turn text into audio in one request, stream the frames back as they render.
+  </Card>
+  <Card title="Clone a voice" icon="microphone" href="/api-v1/post/clone">
+    Bring your own voice with a short reference audio and use it in any synthesis.
+  </Card>
+  <Card title="Browse voices" icon="list" href="/api-v1/get/voices">
+    Bland's curated library plus every voice your org has cloned.
+  </Card>
+</CardGroup>
+
+## Try it
+
+Create an account at [studio.bland.ai/signup](https://studio.bland.ai/signup), grab an API key, then:
+
+```bash
+curl -X POST https://api.bland.ai/v2/tts \
+  -H "authorization: YOUR_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{"text": "Hey, this actually sounds like a person.", "voice": "maya"}' \
+  --output hello.wav
+```
+
+That returns a `wav` you can play. Swap `voice` for any UUID from [List Voices](/api-v1/get/voices).


### PR DESCRIPTION
Linear: [CUS-1119](https://linear.app/blandai/issue/CUS-1119/deliver-tts-docs-on-their-own-site-ttsdocsblandai)

## Summary

Splits the docs navigation into product-scoped tabs so TTS has its own sidebar and reader flow, separate from the voice-agent surface.

Nav changes from `navigation.anchors` to `navigation.products` with three products: **Voice Agents**, **TTS**, **Changelog**. The three href-only anchors (Community, Blog, Enterprise inquiries) move to `navigation.global.anchors` so they persist across every product.

The TTS product carries the endpoints extracted from the old `Voices & Text to Speech` group, reordered around synthesis-first reading order: Get Started, Speech Generation, Streaming, Voice Cloning, Voices, Discovery, Samples, Generation History, Models. The four deprecated `/v1/speak*` pages are dropped from the TTS nav; their `.mdx` files stay on disk and the URLs still resolve.

Adds a new welcome page at `tts/welcome.mdx` as the first entry in the TTS product. Content follows the Bland Speech launch language library (humanlike, built for real conversations, audio realism as the goal, plain-language direction). No unapproved benchmark claims or superlatives.

`tutorials/btts` and `sdks/bland-tts` are referenced from both the Voice Agents Documentation tab and the TTS product's Get Started group. Mint accepts the dual reference.

## Test plan

- [ ] Preview shows three product tabs (Voice Agents, TTS, Changelog)
- [ ] TTS product lands on the welcome page
- [ ] Voice Agents sidebar matches previous minus the TTS group
- [ ] All 16 changelog pages reachable
- [ ] `mint broken-links` passes locally with no new failures