### PR TITLE
BLA-7672 Document call recording access, and fix what was wrong

### DIFF
--- a/api-v1/get/calls-id-recording.mdx
+++ b/api-v1/get/calls-id-recording.mdx
@@ -4,10 +4,12 @@ api: "GET https://api.bland.ai/v1/recordings/{call_id}"
 description: "Retrieve an audio stream for a call recording."
 ---
 
+Whether this endpoint requires credentials depends on your organization's recording access setting. New organizations require an API key or a signed-in dashboard session on every request; organizations that allow unauthenticated access serve the recording to anyone with the link. See [Call Recordings](/platform/call-recordings).
+
 ### Headers
 
-<ParamField header="authorization" type="string" required={true}>
-  Your API key for authentication.
+<ParamField header="authorization" type="string" required={false}>
+  Your API key. Required unless your organization allows unauthenticated access to recordings.
 </ParamField>
 
 <ParamField header="content-type" type="string" required={false}>
@@ -34,6 +36,8 @@ description: "Retrieve an audio stream for a call recording."
 
 <ResponseField name="errors" type="null|array">
   `null` on success, or an array of error objects if access fails.
+
+  A `401` with `AUTHORIZATION_REQUIRED` means the recording requires authentication and none was presented. Retry with your API key.
 </ResponseField>
 
 <ResponseExample>
@@ -44,6 +48,18 @@ description: "Retrieve an audio stream for a call recording."
     {
       "error": "CALL_RECORDING_NOT_FOUND",
       "message": "Call recording not found"
+    }
+  ]
+}
+```
+
+```json Response (authentication required)
+{
+  "data": null,
+  "errors": [
+    {
+      "error": "AUTHORIZATION_REQUIRED",
+      "message": "Authorization required"
     }
   ]
 }

--- a/api-v1/get/calls-id.mdx
+++ b/api-v1/get/calls-id.mdx
@@ -155,6 +155,8 @@ description: "Retrieve detailed information, metadata and transcripts for a call
 
 <ResponseField name="recording_url" type="string">
   The URL of the recording of the call. Only available if `record` was set to `true` in the original API request.
+
+  Whether this URL plays without credentials depends on your organization's recording access setting. New organizations require an API key or a signed-in session on every request. See [Call Recordings](/platform/call-recordings).
 </ResponseField>
 
 <ResponseField name="metadata" type="object">

--- a/api-v1/patch/org_properties.mdx
+++ b/api-v1/patch/org_properties.mdx
@@ -23,8 +23,8 @@ description: "Modify specific properties of an organization."
   <br/><br/>**Valid keys:**  
   - `"org_display_name"` (string) - The display name of the organization. Must be between **1 and 30 characters**.  
   - `"preferences"` (object) - Preference settings for the organization:  
-    - `"use_bland_url"` (boolean) - Whether the organization prefers to use the Bland URL.  
-    - `"recording_lifespan_days"` (integer) - The lifespan of recordings in days. Must be between **1 and 1825** (inclusive) or `-1` to disable retention.  
+    - `"use_bland_url"` (boolean) - Whether `recording_url` is returned as a Bland link rather than a direct link to the host storing the audio. Only affects recordings stored outside Bland (your own Twilio account or S3 bucket).  
+    - `"recording_lifespan_days"` (integer) - How long a recording link plays without authentication. `0` requires authentication on every request, and is the default for new organizations. `1` to `1825` (inclusive) allows unauthenticated playback for that many days after the call, then requires authentication. `-1` never requires authentication and never expires. See [Call Recordings](/platform/call-recordings).  
 </ParamField>  
 
 ### Response
@@ -94,7 +94,11 @@ description: "Modify specific properties of an organization."
 </ResponseField>  
 
 <ResponseField name="data.preferences.use_bland_url" type="boolean">  
-  Whether the organization prefers to use the Bland URL.  
+  Whether `recording_url` is returned as a Bland link rather than a direct link to the host storing the audio.  
+</ResponseField>  
+
+<ResponseField name="data.preferences.recording_lifespan_days" type="integer">  
+  How long a recording link plays without authentication. `0` always requires authentication, `1` to `1825` allows unauthenticated playback for that many days after the call, and `-1` never requires authentication.  
 </ResponseField>  
 
 <ResponseField name="errors" type="null">  
@@ -121,7 +125,8 @@ description: "Modify specific properties of an organization."
     "org_type": "normal",
     "entitlements": [],
     "preferences": {
-      "use_bland_url": false
+      "use_bland_url": true,
+      "recording_lifespan_days": 0
     }
   },
   "errors": null

--- a/api-v1/post/calls.mdx
+++ b/api-v1/post/calls.mdx
@@ -387,6 +387,8 @@ Send an AI phone call with a custom objective and actions. This endpoint can be 
 
 <ParamField body="record" default="false" type="boolean">
   To record your phone call, set `record` to true. When your call completes, you can access through the `recording_url` field in the call details or your webhook.
+
+  Who can play that recording is controlled at the organization level. See [Call Recordings](/platform/call-recordings).
 </ParamField>
 
 ### Voicemail Parameters

--- a/api-v1/post/inbound-number-update.mdx
+++ b/api-v1/post/inbound-number-update.mdx
@@ -571,6 +571,8 @@ Example payloads:
 
 <ParamField body="record" type="boolean" default="false">
   To record your phone call, set `record` to true. When your call completes, you can access through the `recording_url` field in the call details or your webhook.  
+
+  Who can play that recording is controlled at the organization level. See [Call Recordings](/platform/call-recordings).  
 </ParamField>
 
 <ParamField body="citation_schema_ids" type="string[]">

--- a/docs.json
+++ b/docs.json
@@ -87,6 +87,7 @@
                 "group": "Platform Information",
                 "pages": [
                   "platform/static-ips",
+                  "platform/call-recordings",
                   "platform/billing"
                 ]
               },

--- a/llms.txt
+++ b/llms.txt
@@ -66,6 +66,7 @@ Bland holds SOC 2 Type II, HIPAA, GDPR, and PCI DSS certifications. Self-hosted 
 ## Platform Information
 
 - [Static IPs](https://docs.bland.ai/platform/static-ips.md): Source IPs for outbound requests from Bland to customer endpoints.
+- [Call Recordings](https://docs.bland.ai/platform/call-recordings.md): Where call recordings are stored, who can play them, and how to control access.
 - [Billing & Plans](https://docs.bland.ai/platform/billing.md): Understand how usage is billed, available plans, and how to manage billing details.
 
 ## SDKs & Tools

--- a/platform/call-recordings.mdx
+++ b/platform/call-recordings.mdx
@@ -1,0 +1,146 @@
+---
+title: "Call Recordings"
+description: "Where call recordings are stored, who can play them, and how to control access."
+---
+
+## Overview
+
+When you set `record` to `true` on a call, Bland stores the audio and returns a link to it as
+`recording_url` on the call object and in your post-call webhook.
+
+That link points at Bland, not at the underlying storage:
+
+```
+https://api.bland.ai/v1/recordings/{call_id}
+```
+
+Whether the link plays for anyone who has it, or only for an authenticated caller, is controlled by
+one organization-level setting. **New organizations require authentication by default.**
+
+---
+
+## Recording access
+
+Access is governed by `recording_lifespan_days` in your organization's `preferences`. It takes one
+of three kinds of value.
+
+| Value          | Behavior                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------- |
+| `0`            | Authentication is always required. **Default for new organizations.**                        |
+| `1` to `1825`  | The link plays for anyone for that many days after the call, then requires authentication.    |
+| `-1`           | The link never requires authentication and never expires.                                     |
+
+You can change this in the dashboard under **Settings → General → Recording preferences**, or
+through [`PATCH /v1/orgs/{org_id}/properties`](/api-v1/patch/org_properties).
+
+<Info>
+  Organizations created before this default changed keep whatever behavior they had. If
+  `recording_lifespan_days` has never been set on your organization, recordings do not require
+  authentication. Set it explicitly to `0` to require authentication.
+</Info>
+
+### What "requires authentication" means
+
+Requests to a gated recording must present one of:
+
+- **An API key** for the organization that owns the call, as `authorization: <your-api-key>`.
+- **A signed-in dashboard session.** This is what the call detail page uses, so playback and
+  download in the dashboard keep working regardless of this setting.
+
+A request without either receives `401`:
+
+```json
+{
+  "data": null,
+  "errors": [
+    {
+      "error": "AUTHORIZATION_REQUIRED",
+      "message": "Authorization required"
+    }
+  ]
+}
+```
+
+This is an access check, not encryption of the recording itself. Bland verifies the caller and then
+streams the audio; the setting controls who Bland will stream it to.
+
+<Warning>
+  Setting `-1`, or leaving the value unset, means anyone holding a recording link can play it
+  indefinitely. Recording links are long and unguessable, but they are not access-controlled: once
+  a link is shared, forwarded, or written to a log, it stays playable. This includes people who
+  have left your organization.
+</Warning>
+
+### Fetching a recording
+
+```bash
+curl "https://api.bland.ai/v1/recordings/{call_id}" \
+  -H "authorization: <your-api-key>" \
+  --output recording.wav
+```
+
+Pass `content-type: audio/mpeg` for MP3 instead of the default WAV, and `?RequestedChannels=2` for
+a stereo recording with the agent and the caller on separate channels. See
+[Get Call Recording](/api-v1/get/calls-id-recording).
+
+---
+
+## Bland recording URLs
+
+The `use_bland_url` preference controls whether `recording_url` is a Bland link or a direct link to
+whatever stores the audio.
+
+This setting only affects recordings stored **outside** Bland: in your own Twilio account
+([BYOT](/tutorials/custom-twilio)) or your own S3 bucket. Calls recorded on Bland's Twilio account
+always return a Bland link, and those provider URLs are never exposed.
+
+<Warning>
+  Access control can only be enforced on Bland links. If you turn `use_bland_url` off, recordings
+  in your own Twilio account or S3 bucket are handed out as direct provider links. Bland never sees
+  a request for them, so `recording_lifespan_days` does not apply. Anyone with one of those URLs
+  can play the recording.
+</Warning>
+
+---
+
+## Expiration on the call object
+
+When a call finishes, Bland stamps `recording_expiration` on the call record and includes it in the
+post-call webhook. It is an ISO 8601 timestamp marking when the link stops playing without
+authentication.
+
+- With `recording_lifespan_days` set to a number of days, this is the call's start time plus that
+  many days.
+- With `0`, the link requires authentication immediately and `recording_expiration` is not
+  meaningful.
+- With `-1` or unset, no expiration applies.
+
+After that timestamp, the recording is not deleted. It still plays for an authenticated caller.
+Only unauthenticated access stops.
+
+---
+
+## Controlling what gets recorded
+
+Access control decides who can play a recording. These settings decide whether one is made at all.
+
+| Setting                        | Effect                                                                                                      |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `record` on the call           | Records the call. Off by default. See [`POST /v1/calls`](/api-v1/post/calls).                                 |
+| `record_bland_call_only`       | Stops recording when a call is transferred or handed off to a person, so only the agent portion is captured.  |
+| Node-level recording disable   | Turns off recording and transcript logging for a single pathway node, for collecting card or account numbers. |
+
+For consent and disclosure requirements, see the `tcpa:recording_disclosure`
+[guard rail](/tutorials/guard-rails).
+
+---
+
+## Live audio
+
+Recording access is separate from live listening. Streaming a call while it is still in progress is
+controlled by the `live_listen_enabled` preference and always requires authentication. See
+[Listen to a Call](/api-v1/post/calls-id-listen).
+
+---
+
+Docs for agents: [llms.txt](/llms.txt)

--- a/tutorials/post-call-webhooks.mdx
+++ b/tutorials/post-call-webhooks.mdx
@@ -152,7 +152,7 @@ This is the immediate webhook sent right after a call completes:
   },
   "answered_by": "human",
   "record": true,
-  "recording_url": "https://api.twilio.com/2010-04-01/Accounts/ACexample123/Recordings/REexample456",
+  "recording_url": "https://api.bland.ai/v1/recordings/12345678-1234-1234-1234-123456789012",
   "metadata": {
     "campaign_type": "test_calls",
     "environment": "production",
@@ -193,7 +193,7 @@ This is the immediate webhook sent right after a call completes:
     "Intro Node",
     "Call Completion"
   ],
-  "recording_expiration": "2030-10-15T17:20:55.779Z",
+  "recording_expiration": "2025-10-12T20:39:03.168Z",
   "status": "completed",
   "pathway_id": "b71c4c5c-33e3-496b-a5f4-91b7e8e6a931",
   "is_proxy_agent_call": false,
@@ -249,6 +249,21 @@ This is the immediate webhook sent right after a call completes:
 ```
 
 </Accordion>
+
+#### Recording fields
+
+Two fields in the payload relate to the call recording, and both are only present when `record` was
+set to `true`.
+
+| Field                  | Description                                                                                                                                                                       |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `recording_url`        | Where to fetch the audio. Whether it plays without credentials depends on your organization's recording access setting. New organizations require an API key or a signed-in session. |
+| `recording_expiration` | When unauthenticated playback stops, as an ISO 8601 timestamp. Absent when your organization has no expiration configured. The recording is not deleted at this time; only unauthenticated access stops. |
+
+<Info>
+  If you store `recording_url` and fetch it later from a backend service, send your API key with the
+  request. Do not assume the link plays anonymously. See [Call Recordings](/platform/call-recordings).
+</Info>
 
 ### Delayed Webhook with Citations and Corrected Transcript
 
@@ -364,7 +379,7 @@ For detailed configuration options and troubleshooting, see the complete [Citati
   "call_ended_by": "USER",
   "error_message": "Account not allowed to call +12345678901",
   "local_dialing": false,
-  "recording_url": "https://akalocaldev.internal.bland.ai/v1/recordings/8a9620f6-d634-4b92-8d75-93280a894a71:24847607-ce61-4488-be8f-8e63d548b13e",
+  "recording_url": "https://api.bland.ai/v1/recordings/8a9620f6-d634-4b92-8d75-93280a894a71",
   "transferred_at": "2025-10-16T17:10:28.301Z",
   "transferred_to": "+12345678901",
   "disposition_tag": "COMPLETED_ACTION",
@@ -384,7 +399,7 @@ For detailed configuration options and troubleshooting, see the complete [Citati
     ],
     "state": "MERGED"
   },
-  "recording_expiration": "2025-10-19T18:22:36.641+00:00",
+  "recording_expiration": "2025-10-19T18:22:31.000Z",
   "pre_transfer_duration": 0.3955,
   "post_transfer_duration": 0.571166666666667,
   "concatenated_transcript": "assistant: Hey, this is Jean from Nutriva Health. Could you confirm your name for me? \n user: Yeah. My name is James. \n assistant: Hey James, great to meet you! I just wanted to confirm that you’ll be able to attend your upcoming appointment tomorrow at ten A M? \n user: Yeah. I will be able to. Goodbye. \n ",


### PR DESCRIPTION
Docs counterpart to CINTELLILABS/SERVER#10266 (new orgs default to private recordings) and CINTELLILABS/FRONTEND#3535 (settings UI).

## The existing docs were wrong

Before this PR, `recording_lifespan_days` appeared in **exactly one line** across the whole repo (`api-v1/patch/org_properties.mdx:27`):

> The lifespan of recordings in days. Must be between **1 and 1825** (inclusive) or `-1` to disable retention.

Two errors in one sentence:

- **`0` was missing entirely.** It is the "always require authentication" value, and it is now the default for new organizations.
- **`-1` was described backwards.** It does not disable retention. It means the link *never* expires and *never* requires authentication, which is the most public setting available. A customer reading this to lock recordings down would have chosen the value that opens them up permanently.

There was also no prose page about recordings anywhere, so nothing explained who can actually play a `recording_url`.

## What this adds

**New page: `platform/call-recordings.mdx`** (added to the Platform Information group and to `llms.txt`).

Covers how recording URLs are issued, the three access modes with their exact wire values, how to authenticate a request, the `use_bland_url` interaction, `recording_expiration`, and an explicit note that organizations created before this change keep their previous behavior.

It states plainly that this is an **access check, not encryption of the recording**. The endpoint verifies an API key or session and then streams the audio. The dashboard has been calling this "Always Encrypted", which is a false security claim and the main reason customers find the setting confusing.

Also folds in two features that were only ever documented in changelogs: node-level recording disable for PCI, and stop-recording-after-transfer.

## Reference corrections

| File | Fix |
| --- | --- |
| `api-v1/patch/org_properties.mdx` | Rewrite all three values of `recording_lifespan_days`; add the missing response field and update the response example |
| `api-v1/get/calls-id.mdx` | Note that `recording_url` playback depends on the org's access setting |
| `api-v1/get/calls-id-recording.mdx` | Document the `401 AUTHORIZATION_REQUIRED` response; `authorization` is no longer marked unconditionally required |
| `tutorials/post-call-webhooks.mdx` | Describe `recording_url` and `recording_expiration` (both emitted but never defined) and reconcile two contradictory example values |
| `api-v1/post/calls.mdx`, `api-v1/post/inbound-number-update.mdx` | Point the `record` field at the new page |

## Removed a leaked internal hostname

`tutorials/post-call-webhooks.mdx:367` published this in an example payload:

```
https://akalocaldev.internal.bland.ai/v1/recordings/<call_id>:<recording_id>
```

That is an internal hostname, and the `:<recording_id>` suffix is the internal form that bypasses expiration checks; customers never receive it. Replaced with the real public shape. A nearby example also showed a raw Twilio URL exposing an account SID, which contradicted the default behavior, so both now show `api.bland.ai/v1/recordings/{call_id}`.

## Verification

- `mint broken-links`: 6 broken links, all pre-existing in files this PR does not touch (`development.mdx`, `essentials/*`, `tutorials/dynamic-data.mdx`, `tutorials/max-duration.mdx`). Count unchanged by this branch.
- `mint a11y`: no findings on the new page; existing findings are missing image alt text on other pages.
- Every internal link added here resolves to a real page (checked each target file exists).
- No em dashes, per `CLAUDE.md`.
- `docs.json` is valid JSON and the new page appears in navigation and `llms.txt`.

Worth a read for tone and accuracy before merge, particularly the access-mode table and the "what requires authentication means" section.

---

Linear: https://linear.app/blandai/issue/BLA-7672/default-new-orgs-to-private-recordings-and-fix-the-access-messaging