### PR TITLE
Update post-transfer transcript docs for the subscription API

### DIFF
--- a/api-v1/post/calls-id-transcript-stream-token.mdx
+++ b/api-v1/post/calls-id-transcript-stream-token.mdx
@@ -29,7 +29,7 @@ The URL becomes available when the call is answered (that is when the server han
 ## Path Parameters
 
 <ParamField path="call_id" type="string" required>
-  The call whose post-transfer transcript you want to stream. The call must have been created with `include_post_transfer_transcript: true`.
+  The call whose post-transfer transcript you want to stream. The call must have been created with `stream_post_transfer_transcript: true`.
 </ParamField>
 
 ---
@@ -51,7 +51,7 @@ This endpoint takes no body. POST an empty body or `{}`.
 </ResponseField>
 
 <ResponseField name="errors" type="null | array">
-  `null` on success. `401` when the call belongs to a different organization, `403` when the feature is not enabled for your organization, `404` with `CALL_NOT_FOUND` when the call does not exist or has no active transcript stream (not created with `include_post_transfer_transcript`, not yet answered, or already ended).
+  `null` on success. `401` when the call belongs to a different organization, `403` when the feature is not enabled for your organization, `404` with `CALL_NOT_FOUND` when the call does not exist or has no active transcript stream (not created with `stream_post_transfer_transcript`, not yet answered, or already ended).
 </ResponseField>
 
 <RequestExample>

--- a/api-v1/post/calls-id-transcript-stream.mdx
+++ b/api-v1/post/calls-id-transcript-stream.mdx
@@ -5,9 +5,9 @@ description: "Live transcript of the conversation after a call is transferred to
 
 ## Overview
 
-When a call created with `include_post_transfer_transcript: true` is cold-transferred to a human, Bland transcribes the bridged conversation live. Connect to this WebSocket to receive finalized transcript segments as the caller and the transferred-to representative speak.
+When a call created with `stream_post_transfer_transcript: true` is transferred to a human (cold or warm), Bland transcribes the bridged conversation live. Connect to this WebSocket to receive finalized transcript segments as the caller and the transferred-to representative speak.
 
-The stream is a real-time preview. The durable record is the `post_transfer_transcript` property on the [citations webhook](/tutorials/post-call-webhooks#post-transfer-transcript), which carries the same segment format built from the call recording after the call ends.
+The stream is a real-time preview. For a durable record, subscribe with `"post_transfer_transcript"` in `webhook_events`: the [post-call webhook](/tutorials/post-call-webhooks#post-transfer-transcript) then carries the same segment format, built from the call recording after the call ends. The stream and the webhook are independent opt-ins.
 
 <Note>
   The post-transfer transcript stream is in limited rollout. If the [Get Transcript Stream URL endpoint](/api-v1/post/calls-id-transcript-stream-token) returns 403, it is not yet enabled for your organization.
@@ -38,7 +38,7 @@ All messages are JSON text frames.
 
 ### `transcript_segment`
 
-One finalized utterance. Segments are settled text — interim results are never sent — so they arrive at natural pause boundaries, not word by word.
+One finalized utterance. Segments are settled text (interim results are never sent), so they arrive at natural pause boundaries, not word by word.
 
 ```json
 {
@@ -101,7 +101,7 @@ const res = await fetch(
 );
 const { data } = await res.json();
 
-// 2. Connect (safe in a browser — the URL carries only a short-lived credential)
+// 2. Connect (safe in a browser: the URL carries only a short-lived credential)
 const ws = new WebSocket(data.url);
 
 ws.onmessage = (event) => {

--- a/api-v1/post/calls.mdx
+++ b/api-v1/post/calls.mdx
@@ -454,12 +454,10 @@ Send an AI phone call with a custom objective and actions. This endpoint can be 
   > Note: Citation schemas are very powerful and accurate, but also are more resource intensive to run. As such, for the time being, they are an enterprise-only feature.
 </ParamField>
 
-<ParamField body="include_post_transfer_transcript" type="boolean" default="false">
-  When `true` and the call is cold-transferred to a human, Bland transcribes the conversation after the transfer and delivers it two ways: live over the [Post-Transfer Transcript Stream](/api-v1/post/calls-id-transcript-stream) WebSocket while the transferred conversation is happening, and post-call as a `post_transfer_transcript` property (plus `transfer_offset_seconds`) on the `citations` webhook event.
+<ParamField body="stream_post_transfer_transcript" type="boolean" default="false">
+  When `true` and the call is transferred to a human, Bland transcribes the conversation after the transfer live and streams it over the [Post-Transfer Transcript Stream](/api-v1/post/calls-id-transcript-stream) WebSocket while the transferred conversation is happening. Works for both cold and warm transfers.
 
-  Requires call recording: `record` is enabled automatically when unset, and passing `record: false` alongside this option returns a 400.
-
-  The post-call delivery rides on the citations webhook, so to receive it you also need at least one schema in `citation_schema_ids` and `"citations"` in `webhook_events`.
+  This option controls the live stream only. To receive the post-transfer transcript in the post-call webhook, subscribe with `"post_transfer_transcript"` in `webhook_events`. The two are independent: you can use either one or both.
 
   <Note>
     This feature is in limited rollout. If it is not enabled for your organization, the option has no effect.
@@ -619,6 +617,8 @@ Send an AI phone call with a custom objective and actions. This endpoint can be 
   - `tool`
   - `dynamic_data`
   - `citations` (Required for any citation webhooks)
+  - `evals` (Eval scores from an attached [evals workbench](/tutorials/evals), sent as a separate webhook when the run completes)
+  - `post_transfer_transcript` (Adds the post-transfer conversation to the post-call webhook when the call is transferred to a human; see [Post-transfer transcript](/tutorials/post-call-webhooks#post-transfer-transcript). Requires call recording: `record` is enabled automatically when unset, and passing `record: false` alongside this subscription returns a 400.)
 
   Example payloads:
 

--- a/api-v1/post/calls.mdx
+++ b/api-v1/post/calls.mdx
@@ -618,7 +618,7 @@ Send an AI phone call with a custom objective and actions. This endpoint can be 
   - `dynamic_data`
   - `citations` (Required for any citation webhooks)
   - `evals` (Eval scores from an attached [evals workbench](/tutorials/evals), sent as a separate webhook when the run completes)
-  - `post_transfer_transcript` (Adds the post-transfer conversation to the post-call webhook when the call is transferred to a human; see [Post-transfer transcript](/tutorials/post-call-webhooks#post-transfer-transcript). Requires call recording: `record` is enabled automatically when unset, and passing `record: false` alongside this subscription returns a 400.)
+  - `post_transfer_transcript` (Adds the post-transfer conversation to the post-call webhook when the call is transferred to a human; see [Post-transfer transcript](/tutorials/post-call-webhooks#post-transfer-transcript). Requires call recording: `record` is enabled automatically when unset, and passing `record: false` alongside this subscription returns a 400. In limited rollout: if not enabled for your organization, the subscription has no effect.)
 
   Example payloads:
 

--- a/tutorials/post-call-webhooks.mdx
+++ b/tutorials/post-call-webhooks.mdx
@@ -499,10 +499,12 @@ For detailed configuration options and troubleshooting, see the complete [Citati
   The post-transfer transcript is in limited rollout. If it is not enabled for your organization, these properties are absent.
 </Note>
 
-Calls created with [`include_post_transfer_transcript: true`](/api-v1/post/calls#param-include-post-transfer-transcript) that were cold-transferred to a human carry two additional properties on the `citations` event (in both the standalone and delayed delivery modes):
+To receive the post-transfer transcript, subscribe by including `"post_transfer_transcript"` in the call's `webhook_events`. No citation schema is needed. Subscribing requires call recording: `record` is enabled automatically when unset, and passing `record: false` alongside the subscription returns a 400. Both cold and warm transfers are covered.
 
-- `transfer_offset_seconds` — seconds from the start of the call to the transfer.
-- `post_transfer_transcript` — the conversation after the transfer, as speaker-attributed segments. The transferred-to human is `speaker: 2` / `"representative"`; the caller is `speaker: 1` / `"user"`. Timestamps are seconds from the start of the transferred conversation. The `corrected_transcript` continues to contain only the pre-transfer portion of the call.
+Subscribed calls that were transferred to a human carry two additional properties on the post-processing webhook (in both the standalone and delayed delivery modes):
+
+- `transfer_offset_seconds`: seconds from the start of the call to the transfer.
+- `post_transfer_transcript`: the conversation after the transfer, as speaker-attributed segments. The transferred-to human is `speaker: 2` / `"representative"`; the caller is `speaker: 1` / `"user"`. Timestamps are seconds from the start of the transferred conversation. The `corrected_transcript` continues to contain only the pre-transfer portion of the call.
 
 ```json
 {
@@ -528,7 +530,18 @@ Calls created with [`include_post_transfer_transcript: true`](/api-v1/post/calls
 }
 ```
 
-The same segment format is available live during the transferred conversation via the [Post-Transfer Transcript Stream](/api-v1/post/calls-id-transcript-stream) WebSocket.
+For subscribed calls, the post-processing webhook also labels what it contains. When the payload carries exactly one enrichment, `event_type` names it (for example `"post_transfer_transcript"` or `"citations"`). When it carries more than one, `event_type` is `"multiple"` and a `contents` array lists what is present, in a fixed order:
+
+```json
+{
+  "event_type": "multiple",
+  "contents": ["citations", "post_transfer_transcript"]
+}
+```
+
+`contents` can list `citations`, `corrected_transcript`, `dispositions`, `post_transfer_transcript`, and `live_translation_transcript`. Calls without the `post_transfer_transcript` subscription are unaffected: their payloads are unchanged.
+
+The same segment format is available live during the transferred conversation via the [Post-Transfer Transcript Stream](/api-v1/post/calls-id-transcript-stream) WebSocket. The live stream is enabled separately with [`stream_post_transfer_transcript: true`](/api-v1/post/calls#param-stream-post-transfer-transcript); it does not require the webhook subscription, and the webhook subscription does not require the stream.
 
 ---
 


### PR DESCRIPTION
Matches the shipped API (SERVER #10163 / #10194 / #10195).

- Send Call: `stream_post_transfer_transcript` replaces the old flag and now controls only the live stream. `webhook_events` gains `post_transfer_transcript` (webhook delivery, recording required) and `evals`.
- Transcript stream pages: new flag name; warm transfers now covered, not just cold.
- Post-call webhooks tutorial: delivery comes from the `post_transfer_transcript` subscription rather than the citations webhook, with no citation schema requirement. Documents the `event_type` / `multiple` / `contents` labeling for subscribed calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)